### PR TITLE
Add SMART Health Links eligibility example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A collection of examples on top of Aidbox FHIR platform
 - [Real-Time Analytics with Aidbox, ClickHouse, and Superset](aidbox-integrations/clickhouse-superset/)
 - [GraphQL Federation](aidbox-integrations/apollo-graphql-federation/)
 - [FHIR R5 Topic-Based Subscriptions](aidbox-integrations/r5-subscriptions/)
+- [SMART Health Links for eligibility results](aidbox-integrations/smart-health-link/)
 
 ## Aidbox Features
 

--- a/aidbox-integrations/smart-health-link/.dockerignore
+++ b/aidbox-integrations/smart-health-link/.dockerignore
@@ -1,0 +1,27 @@
+# Dependencies
+node_modules
+npm-debug.log
+
+# Source control
+.git
+.gitignore
+
+# Environment files (use env vars or mounted configs instead)
+.env*
+!.env.example
+
+# Development files
+.vscode
+.DS_Store
+*.log
+temp
+
+# Documentation
+README.md
+docs
+adr
+
+# Docker files (don't include in image)
+Dockerfile*
+docker-compose*.yaml
+.dockerignore

--- a/aidbox-integrations/smart-health-link/.env.example
+++ b/aidbox-integrations/smart-health-link/.env.example
@@ -1,0 +1,27 @@
+# Aidbox Configuration
+# Bare host — the Aidbox client appends /fhir itself.
+AIDBOX_BASE_URL=http://localhost:8080
+AIDBOX_CLIENT_ID=shl-client
+AIDBOX_CLIENT_SECRET=secret
+
+# SMART Health Link Configuration
+# Public base URL of THIS app, as reachable by the SHL receiver/browser.
+# The manifest URL embedded in the shlink: is built from this.
+SHL_PUBLIC_BASE_URL=http://localhost:8080/shl-app
+# SHL viewer prepended to the shlink: (must end with #). Points at the in-app
+# viewer so minted links open it with the SHL prefilled. Leave empty for a bare shlink:.
+SHL_VIEWER_URL=http://localhost:3000/#
+
+# Simulated real-time eligibility (RTE) processing delay, in seconds
+RTE_PROCESSING_SECONDS=10
+
+# SHL protocol policy
+# Lifetime incorrect-passcode attempts before a P-flag link locks
+SHL_PASSCODE_MAX_ATTEMPTS=5
+# Lifetime of a manifest-issued `location` URL, in seconds (spec allows <= 3600)
+SHL_FILE_TOKEN_TTL_SECONDS=60
+# Minimum seconds between manifest polls for one link before returning 429
+SHL_MANIFEST_MIN_INTERVAL_SECONDS=1
+
+# Server Configuration
+PORT=3000

--- a/aidbox-integrations/smart-health-link/.gitignore
+++ b/aidbox-integrations/smart-health-link/.gitignore
@@ -1,0 +1,20 @@
+# Dependencies
+node_modules/
+
+# Logs
+logs/
+*.log
+
+# Environment variables
+.env
+.env.local
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/aidbox-integrations/smart-health-link/CLAUDE.MD
+++ b/aidbox-integrations/smart-health-link/CLAUDE.MD
@@ -1,0 +1,39 @@
+# Project Overview
+
+This project implements **SMART Health Links (SHL)** in TypeScript on the [Bun](https://bun.sh) runtime, integrated with Aidbox. It securely shares the result of a long-running **real-time eligibility (RTE)** check with an **unauthenticated** client: the client kicks off the check, receives a `shlink:` carrying an encryption key, polls a manifest until the result is ready, then decrypts it. The SHL key is the only secret — the server stores only ciphertext. The implementation should be minimal and focused on core functionality.
+
+## Architecture
+
+- **FHIR Server**: Aidbox with custom operation routing (Aidbox Apps) and a `SHLink` custom resource
+- **Application**: Bun + TypeScript service (no build step — Bun runs TS directly)
+- **Integration**: Aidbox proxies App operations to the service; the service calls back into Aidbox via the FHIR API
+- **Output**: A FHIR `CoverageEligibilityResponse`, encrypted as a JWE (`alg: dir`, `enc: A256GCM`)
+- **Viewer**: a self-contained browser page (`src/viewer.html`, served at `GET /`) that resolves a `shlink:` and decrypts it client-side with WebCrypto — the realistic SHL receiver. `SHL_VIEWER_URL` is wired to it so minted links open it prefilled.
+
+## Key Resources
+
+### Specification
+- **SMART Health Links IG**: https://hl7.org/fhir/uv/smart-health-cards-and-links/STU1/links-specification.html
+- **Flags used**: `L` (long-term). Not used: `P` (passcode), `U` (direct file).
+
+### Aidbox Integration
+- **Init Bundle**: `init-bundle/bundle.json` — Client, AccessPolicy, `SHLink` StructureDefinition, and the `shl-app` App with three operations (kickoff is authenticated; manifest and file are public via an inline `allow` policy).
+- **App Resource**: routes `$kickoff`, `manifest/{shlId}`, and `file/{fileId}` to the Bun service. See [Aidbox Apps](https://www.health-samurai.io/docs/aidbox/app-development/aidbox-sdk/apps).
+- **Custom Resource**: `SHLink` persists per-link state (key, jobStatus, encrypted file).
+
+## Development Commands
+
+```bash
+bun install        # install dependencies
+bun run dev        # watch mode (bun --watch)
+bun run start      # run once
+bunx tsc --noEmit  # type-check
+docker compose up --build   # full stack (Aidbox + app)
+```
+
+## Project Scope
+
+- **Backend only**: no frontend UI.
+- **Core functionality**: mint SHL, async RTE job, manifest lifecycle (can-change → finalized), encrypted file delivery, decryption.
+- **Runtime**: Bun (native `Bun.serve` HTTP, auto-loaded `.env`, direct TypeScript execution — no `tsc`/`ts-node`/`nodemon`).
+- **FHIR access**: the official `@health-samurai/aidbox-client` (Basic auth via `BasicAuthProvider`, typed `AidboxClient` returning a `Result`), as in `aidbox-features/aidbox-orchestration-service`.

--- a/aidbox-integrations/smart-health-link/CLAUDE.MD
+++ b/aidbox-integrations/smart-health-link/CLAUDE.MD
@@ -33,7 +33,7 @@ docker compose up --build   # full stack (Aidbox + app)
 
 ## Project Scope
 
-- **Backend only**: no frontend UI.
-- **Core functionality**: mint SHL, async RTE job, manifest lifecycle (can-change → finalized), encrypted file delivery, decryption.
+- **Backend + a self-contained demo viewer**: the focus is the backend SHL flow; `src/viewer.html` is a single-file browser receiver (no build, no framework) included to exercise it end to end.
+- **Core functionality**: mint SHL, async RTE job, manifest lifecycle (can-change → finalized), encrypted file delivery, and client-side decryption in the viewer.
 - **Runtime**: Bun (native `Bun.serve` HTTP, auto-loaded `.env`, direct TypeScript execution — no `tsc`/`ts-node`/`nodemon`).
 - **FHIR access**: the official `@health-samurai/aidbox-client` (Basic auth via `BasicAuthProvider`, typed `AidboxClient` returning a `Result`), as in `aidbox-features/aidbox-orchestration-service`.

--- a/aidbox-integrations/smart-health-link/Dockerfile
+++ b/aidbox-integrations/smart-health-link/Dockerfile
@@ -1,0 +1,23 @@
+# Use the official Bun image
+FROM oven/bun:1-alpine
+
+# Install curl for the container healthcheck
+RUN apk add --no-cache curl
+
+WORKDIR /app
+
+# Install dependencies first (better layer caching)
+COPY package.json bun.lock* ./
+RUN bun install
+
+# Copy source
+COPY . .
+
+# Run as the non-root user that the Bun image ships with
+USER bun
+
+# Expose port
+EXPOSE 3000
+
+# Bun runs TypeScript directly — no build step
+CMD ["bun", "src/server.ts"]

--- a/aidbox-integrations/smart-health-link/README.md
+++ b/aidbox-integrations/smart-health-link/README.md
@@ -24,21 +24,15 @@ The link carries a key because there is no logged-in user to protect the data, a
 
 ```mermaid
 flowchart LR
-    Client[Prospective member<br/>client app]
-    Aidbox[Aidbox<br/>FHIR Server]
-    App[SHL App<br/>Bun + TypeScript]
+    C["Client (browser)<br/>prospective member"]
+    A["Aidbox (FHIR server)<br/>routes operations, stores the SHLink"]
+    S["SHL App (Bun backend)<br/>SHL logic + eligibility job"]
+    P["Payer<br/>eligibility source (simulated)"]
 
-    Client -->|1. POST $kickoff| Aidbox
-    Aidbox -->|operation| App
-    App -->|shlink: + key| Client
-    App -.->|async: produce + encrypt result| Aidbox
-    Client -->|2. POST manifest no-auth| Aidbox
-    Aidbox -->|operation| App
-    App -->|status + encrypted file| Client
-
-    style Aidbox fill:#e1f5fe
-    style App fill:#f3e5f5
-    style Client fill:#e8f5e8
+    C <-->|"HTTP: kickoff / manifest / file"| A
+    A -->|"proxies operations"| S
+    S -->|"stores the encrypted SHLink"| A
+    S -->|"checks eligibility (RTE)"| P
 ```
 
 **Components:**
@@ -46,6 +40,30 @@ flowchart LR
 - **Application**: Bun/TypeScript service implementing the SHL kickoff, manifest, and file operations.
 
 **Output:** the content shared through the link is a FHIR `CoverageEligibilityResponse`, encrypted as a JWE (`alg: dir`, `enc: A256GCM`) under the SHL key.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    actor C as Client (browser)
+    participant A as Aidbox (FHIR server)
+    participant S as SHL App (Bun backend)
+    participant P as Payer
+
+    C->>A: POST $kickoff (member details)
+    A->>S: Aidbox routes the call to the backend
+    S-->>C: shlink: + key (returned right away)
+
+    Note over S,P: background job (the payer call is simulated here)
+    S->>P: check eligibility (RTE)
+    P-->>S: eligibility result
+    S->>A: encrypt the result, store it on the SHLink
+
+    C->>A: POST manifest (poll, no auth)
+    A->>S: Aidbox routes the call to the backend
+    S-->>C: status; once ready, the encrypted file
+    Note over C: decrypt locally with the key from the link
+```
 
 ## Aidbox resources
 

--- a/aidbox-integrations/smart-health-link/README.md
+++ b/aidbox-integrations/smart-health-link/README.md
@@ -1,0 +1,215 @@
+---
+features: [SMART Health Links, Async eligibility (RTE), JWE encryption, Custom resources, Aidbox Apps]
+languages: [TypeScript]
+runtimes: [Bun]
+---
+# SMART Health Links — Async Eligibility Sharing
+
+A minimal TypeScript ([Bun](https://bun.sh)) implementation of [SMART Health Links (SHL)](https://hl7.org/fhir/uv/smart-health-cards-and-links/STU1/links-specification.html), integrated with Aidbox, that securely shares the result of a long-running **real-time eligibility (RTE)** check with an **unauthenticated** client.
+
+## Use case
+
+A prospective member wants to check whether they're eligible for a service **before** registering — so there is no authenticated user yet. The eligibility lookup is asynchronous and can take a while:
+
+1. The client **kicks off** the check and immediately receives a `shlink:` (containing a one-time encryption key).
+2. The client **polls** the SHL manifest. While the job runs, the manifest reports `can-change`.
+3. When the result is ready, the manifest reports `finalized` and serves the result **encrypted**.
+4. The client **decrypts** the result with the key from its `shlink:`.
+
+The security property that makes this work without auth: **the SHL key is the only secret**. The server only ever stores ciphertext, the manifest/file endpoints are public, and only the client that kicked off the job (the holder of the key) can read the result — exactly the requirement that motivated this example.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Client[Client<br/>prospective member]
+    Aidbox[Aidbox<br/>FHIR Server]
+    App[SHL App<br/>Bun + TypeScript]
+
+    Client -->|1. POST $kickoff| Aidbox
+    Aidbox -->|operation| App
+    App -->|shlink: + key| Client
+    App -.->|async: produce + encrypt result| Aidbox
+    Client -->|2. POST manifest no-auth| Aidbox
+    Aidbox -->|operation| App
+    App -->|status + encrypted file| Client
+
+    style Aidbox fill:#e1f5fe
+    style App fill:#f3e5f5
+    style Client fill:#e8f5e8
+```
+
+**Components:**
+- **FHIR Server**: Aidbox with [custom operation routing](https://www.health-samurai.io/docs/aidbox/app-development/aidbox-sdk/apps) and a `SHLink` [custom resource](https://www.health-samurai.io/docs/aidbox/tutorials/artifact-registry-tutorials/custom-resources).
+- **Application**: Bun/TypeScript service implementing the SHL kickoff, manifest, and file operations.
+- **Result**: A FHIR `CoverageEligibilityResponse`, encrypted as a JWE (`alg: dir`, `enc: A256GCM`) under the SHL key.
+
+## SHL endpoints
+
+All three are Aidbox App operations, proxied to the Bun service. Manifest and file are **public** (bound to an `allow` policy); kickoff is authenticated.
+
+| Operation | Method | Path | Auth | Purpose |
+|-----------|--------|------|------|---------|
+| `shl-kickoff` | POST | `/shl-app/eligibility/$kickoff` | required | Start an RTE job, mint a `shlink:` |
+| `shl-manifest` | POST | `/shl-app/manifest/{shlId}` | public | SHL manifest request |
+| `shl-file` | GET | `/shl-app/file/{fileId}` | public | Short-lived encrypted file fetch |
+
+The Bun app also serves the demo UI directly (not via Aidbox): `GET /` (the viewer) and `POST /demo/kickoff` (an unauthenticated convenience trigger the viewer uses to start a check — see the note under "Testing the flow").
+
+## Quick Start
+
+### Prerequisites
+- Docker and Docker Compose
+- [Bun](https://bun.sh) 1.x (for local development)
+
+### Running the application
+
+1. **Create .env file** (optional — defaults match `docker-compose.yaml`):
+   ```bash
+   cp .env.example .env
+   ```
+
+2. **Run docker compose**:
+   ```bash
+   docker compose up --build
+   ```
+
+3. **Initialize Aidbox**: navigate to the [Aidbox UI](http://localhost:8080) and [activate the instance](https://www.health-samurai.io/docs/aidbox/getting-started/run-aidbox-locally#activate-your-aidbox-instance). The init bundle registers the `shl-client`, the `SHLink` custom resource, and the `shl-app` App.
+
+4. **Open the viewer**: the SHL viewer is at [http://localhost:3000](http://localhost:3000). After you kick off a check (below), the returned `shlink:` opens straight into it.
+
+### Local development (without Docker for the app)
+
+```bash
+bun install
+bun run dev      # watch mode
+```
+
+## Testing the flow
+
+### The whole flow in the browser (recommended)
+
+Open the viewer at **[http://localhost:3000](http://localhost:3000)** — it drives the entire use case end to end:
+
+1. **Start a check** — enter a member name, payer, and member ID, then press **Start check**. This mints a `shlink:` (shown with a copy button) and starts the async eligibility job.
+2. **Watch it resolve** — the stepper runs the real receiver protocol: decode the link → **poll the manifest** (`can-change` while the job runs, then `finalized`) → fetch the encrypted file → **decrypt in your browser** (WebCrypto AES-256-GCM). **Click any step** to expand the exact HTTP call behind it — the real request and the live response it received (long keys/JWEs truncated for readability).
+3. **Read the result** — the decrypted `CoverageEligibilityResponse` renders inline. The key never leaves the page; the server only ever sees ciphertext.
+
+The **Open a link** tab does just the receiver half — paste any `shlink:` (or open a viewer-prefixed link, which fills it in and runs automatically).
+
+> The viewer's **Start check** calls an unauthenticated demo route (`POST /demo/kickoff`) on the app so the browser holds no Aidbox credentials. In production, kickoff is the authenticated `shl-kickoff` operation triggered by a back-office service.
+
+### The same flow at the API level
+
+Use the [Aidbox REST Console](http://localhost:8080/u/rest) or `curl`.
+
+#### 1. Kick off an eligibility check
+
+```http
+POST /shl-app/eligibility/$kickoff
+Content-Type: application/fhir+json
+
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    { "name": "memberName", "valueString": "Jane Prospect" },
+    { "name": "payerName",  "valueString": "Acme Health" },
+    { "name": "memberId",   "valueString": "M-99887" }
+  ]
+}
+```
+
+Response:
+```json
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    { "name": "shlinkId",    "valueString": "029f90da-..." },
+    { "name": "shlink",      "valueString": "shlink:/eyJ1cmwiOiJodHRw..." },
+    { "name": "manifestUrl", "valueString": "http://localhost:8080/shl-app/manifest/029f90da-..." }
+  ]
+}
+```
+
+#### 2. Poll the manifest (no auth required)
+
+```http
+POST /shl-app/manifest/{shlId}
+Content-Type: application/json
+
+{ "recipient": "Jane on her phone" }
+```
+
+While the job runs:
+```json
+{ "status": "can-change", "files": [] }
+```
+
+After ~10s (the simulated RTE delay), the result is ready:
+```json
+{
+  "status": "finalized",
+  "files": [
+    { "contentType": "application/fhir+json", "embedded": "<JWE compact serialization>" }
+  ]
+}
+```
+
+If you send `embeddedLengthMax` smaller than the JWE, the manifest returns a short-lived `location` URL instead of `embedded`:
+```http
+GET /shl-app/file/{fileId}    # returns the JWE as application/jose
+```
+
+#### 3. Decrypt the result
+
+In the browser, use the viewer above. In code, the `shlink:` payload (base64url JSON) contains the `key` — decode it and decrypt the JWE with AES-256-GCM:
+
+```ts
+import { decodeShlink } from "./src/utils/shl-encode.ts";
+import { decryptJwe } from "./src/utils/crypto.ts";
+
+const payload = decodeShlink(shlink);              // { url, key, flag: "L", label, v }
+const fhir = JSON.parse(await decryptJwe(jwe, payload.key));
+// -> CoverageEligibilityResponse
+```
+
+Only the `key` from the `shlink:` decrypts the file. Without it, the ciphertext is unreadable — which is how the result stays private to the client that started the job.
+
+## Project layout
+
+```
+src/
+├── server.ts                 # Bun.serve; dispatches Aidbox operations + serves the viewer
+├── viewer.html               # browser SHL viewer (client-side WebCrypto decryption)
+├── handlers/
+│   └── shl.ts                # kickoff / manifest / file handlers
+├── services/
+│   ├── fhir-client.ts        # wraps @health-samurai/aidbox-client (Basic auth)
+│   ├── shlink-store.ts       # SHLink custom-resource persistence
+│   ├── eligibility.ts        # builds the CoverageEligibilityResponse (RTE result)
+│   └── shl-service.ts        # mint / manifest / file orchestration + async job
+├── types/
+│   ├── config.ts             # env-driven config
+│   ├── operation.ts          # Aidbox operation request envelope
+│   ├── shl.ts                # SHL payload / manifest types
+│   └── shlink-resource.ts    # SHLink custom resource shape
+└── utils/
+    ├── crypto.ts             # key generation + JWE encrypt/decrypt (jose)
+    └── shl-encode.ts         # shlink: encode/decode
+```
+
+## Protocol hardening
+
+Beyond the happy path, the example implements the security-sensitive plumbing of the SHL spec — the parts you don't want every integrator reimplementing:
+
+- **Passcode (`P` flag)** — pass a `passcode` to kickoff and the link carries `flag: "LP"`. The manifest then requires it: a missing one returns `401 { "message": "Passcode required" }`, a wrong one returns `401 { "remainingAttempts": N }`. The attempt counter is a **lifetime** total persisted on the `SHLink` (and decremented before responding), so it holds up against parallel guessing. Once it hits zero the link locks — even the correct passcode then resolves to `no-longer-valid`.
+- **Short-lived `location` URLs** — when the manifest hands back a `location` instead of an `embedded` file, it mints a per-request token with an expiry (`SHL_FILE_TOKEN_TTL_SECONDS`, default 60s; the spec allows ≤ 1 hour). Fetching after it expires returns `410 Gone`.
+- **Poll throttling** — polling one link's manifest faster than `SHL_MANIFEST_MIN_INTERVAL_SECONDS` returns `429` with a `Retry-After` header; the viewer honors it.
+
+Tunable via env (see `.env.example`): `SHL_PASSCODE_MAX_ATTEMPTS`, `SHL_FILE_TOKEN_TTL_SECONDS`, `SHL_MANIFEST_MIN_INTERVAL_SECONDS`.
+
+## Notes & scope
+
+- **Flags**: uses `L` (long-term, since the manifest evolves pending → ready) and optionally `P` (passcode). It does not implement `U` (direct file) — see the SHL spec.
+- **Key storage**: the SHL key is persisted on the `SHLink` resource so the background worker can encrypt the result once the RTE job finishes. In production you'd avoid long-term key storage (hold it only in the worker, or encrypt-on-write and discard) — this is the one deliberate simplification, flagged because it's the central security tradeoff of the design.
+- **Out of scope**: real payer RTE (270/271) integration, `location` single-use enforcement (only expiry is enforced here), key rotation.

--- a/aidbox-integrations/smart-health-link/README.md
+++ b/aidbox-integrations/smart-health-link/README.md
@@ -3,26 +3,28 @@ features: [SMART Health Links, Async eligibility (RTE), JWE encryption, Custom r
 languages: [TypeScript]
 runtimes: [Bun]
 ---
-# SMART Health Links — Async Eligibility Sharing
+# SMART Health Links: Async Eligibility Sharing
 
-A minimal TypeScript ([Bun](https://bun.sh)) implementation of [SMART Health Links (SHL)](https://hl7.org/fhir/uv/smart-health-cards-and-links/STU1/links-specification.html), integrated with Aidbox, that securely shares the result of a long-running **real-time eligibility (RTE)** check with an **unauthenticated** client.
+A small TypeScript ([Bun](https://bun.sh)) implementation of [SMART Health Links (SHL)](https://hl7.org/fhir/uv/smart-health-cards-and-links/STU1/links-specification.html) on Aidbox. It shares the result of a slow **real-time eligibility (RTE)** check with a client that has no account, and keeps that result private to the client.
 
 ## Use case
 
-A prospective member wants to check whether they're eligible for a service **before** registering — so there is no authenticated user yet. The eligibility lookup is asynchronous and can take a while:
+Someone is thinking about signing up. First they want to know: *am I covered, and what will it cost me?* They have no account yet, so nothing can log them in. The answer also takes a few seconds, because the app has to check coverage with the payer.
 
-1. The client **kicks off** the check and immediately receives a `shlink:` (containing a one-time encryption key).
-2. The client **polls** the SHL manifest. While the job runs, the manifest reports `can-change`.
-3. When the result is ready, the manifest reports `finalized` and serves the result **encrypted**.
-4. The client **decrypts** the result with the key from its `shlink:`.
+From the person's side:
 
-The security property that makes this work without auth: **the SHL key is the only secret**. The server only ever stores ciphertext, the manifest/file endpoints are public, and only the client that kicked off the job (the holder of the key) can read the result — exactly the requirement that motivated this example.
+1. **They enter their details** (name, insurance/payer, member ID) and start the check.
+2. **They get a link back right away** (a `shlink:`). It carries a one-time key that only they hold. The coverage check runs in the background.
+3. **They wait** while the app asks "is the result ready yet?" until the payer answers.
+4. **They see the result.** The app fetches the encrypted answer and decrypts it on their device with the key from the link.
+
+The link carries a key because there is no logged-in user to protect the data, and the answer isn't ready when the request comes in. The key is the only secret: the server stores nothing but ciphertext, the endpoints that serve it stay public, and only the person holding the link can read the result. No account, and nothing readable sits on the server.
 
 ## Architecture
 
 ```mermaid
 flowchart LR
-    Client[Client<br/>prospective member]
+    Client[Prospective member<br/>client app]
     Aidbox[Aidbox<br/>FHIR Server]
     App[SHL App<br/>Bun + TypeScript]
 
@@ -42,7 +44,21 @@ flowchart LR
 **Components:**
 - **FHIR Server**: Aidbox with [custom operation routing](https://www.health-samurai.io/docs/aidbox/app-development/aidbox-sdk/apps) and a `SHLink` [custom resource](https://www.health-samurai.io/docs/aidbox/tutorials/artifact-registry-tutorials/custom-resources).
 - **Application**: Bun/TypeScript service implementing the SHL kickoff, manifest, and file operations.
-- **Result**: A FHIR `CoverageEligibilityResponse`, encrypted as a JWE (`alg: dir`, `enc: A256GCM`) under the SHL key.
+
+**Output:** the content shared through the link is a FHIR `CoverageEligibilityResponse`, encrypted as a JWE (`alg: dir`, `enc: A256GCM`) under the SHL key.
+
+## Aidbox resources
+
+The [init bundle](init-bundle/bundle.json) provisions four resources at startup. The flow creates two more at runtime.
+
+| Resource | Created | Why |
+|----------|---------|-----|
+| `Client/shl-client` | init bundle | The M2M client the Bun app uses to call Aidbox's FHIR API (Basic auth). |
+| `AccessPolicy/shl-client-policy` | init bundle | Grants `shl-client` access to Aidbox (`allow` engine). |
+| `StructureDefinition/SHLink` | init bundle | Defines the `SHLink` [custom resource](https://www.health-samurai.io/docs/aidbox/tutorials/artifact-registry-tutorials/custom-resources): the server-side state of one link (key, encrypted file, job status, passcode, throttling, file tokens). |
+| `App/shl-app` | init bundle | Registers the app and routes the three operations: `$kickoff` (authenticated), `manifest` and `file` (public). |
+| `SHLink/{id}` | runtime, one per kickoff | Holds that link's key and job status, then the encrypted JWE once the result is ready. |
+| `CoverageEligibilityResponse/{id}` | runtime, one per check | The eligibility result the job produces. Its JSON is what gets encrypted into the link. |
 
 ## SHL endpoints
 
@@ -54,7 +70,7 @@ All three are Aidbox App operations, proxied to the Bun service. Manifest and fi
 | `shl-manifest` | POST | `/shl-app/manifest/{shlId}` | public | SHL manifest request |
 | `shl-file` | GET | `/shl-app/file/{fileId}` | public | Short-lived encrypted file fetch |
 
-The Bun app also serves the demo UI directly (not via Aidbox): `GET /` (the viewer) and `POST /demo/kickoff` (an unauthenticated convenience trigger the viewer uses to start a check — see the note under "Testing the flow").
+The Bun app also serves the demo UI directly (not via Aidbox): `GET /` (the viewer) and `POST /demo/kickoff` (an unauthenticated convenience trigger the viewer uses to start a check; see the note under "Testing the flow").
 
 ## Quick Start
 
@@ -64,7 +80,7 @@ The Bun app also serves the demo UI directly (not via Aidbox): `GET /` (the view
 
 ### Running the application
 
-1. **Create .env file** (optional — defaults match `docker-compose.yaml`):
+1. **Create .env file** (optional; defaults match `docker-compose.yaml`):
    ```bash
    cp .env.example .env
    ```
@@ -89,13 +105,13 @@ bun run dev      # watch mode
 
 ### The whole flow in the browser (recommended)
 
-Open the viewer at **[http://localhost:3000](http://localhost:3000)** — it drives the entire use case end to end:
+Open the viewer at **[http://localhost:3000](http://localhost:3000)**. It runs the entire use case end to end:
 
-1. **Start a check** — enter a member name, payer, and member ID, then press **Start check**. This mints a `shlink:` (shown with a copy button) and starts the async eligibility job.
-2. **Watch it resolve** — the stepper runs the real receiver protocol: decode the link → **poll the manifest** (`can-change` while the job runs, then `finalized`) → fetch the encrypted file → **decrypt in your browser** (WebCrypto AES-256-GCM). **Click any step** to expand the exact HTTP call behind it — the real request and the live response it received (long keys/JWEs truncated for readability).
-3. **Read the result** — the decrypted `CoverageEligibilityResponse` renders inline. The key never leaves the page; the server only ever sees ciphertext.
+1. **Start a check.** Enter a member name, payer, and member ID, then press **Start check**. This mints a `shlink:` (shown with a copy button) and starts the async eligibility job.
+2. **Watch it resolve.** The stepper runs the real receiver protocol: decode the link → **poll the manifest** (`can-change` while the job runs, then `finalized`) → fetch the encrypted file → **decrypt in your browser** (WebCrypto AES-256-GCM). Click any step to expand the exact HTTP call behind it: the real request and the live response it received (long keys and JWEs truncated for readability).
+3. **Read the result.** The decrypted `CoverageEligibilityResponse` renders inline. The key never leaves the page, and the server only ever sees ciphertext.
 
-The **Open a link** tab does just the receiver half — paste any `shlink:` (or open a viewer-prefixed link, which fills it in and runs automatically).
+The **Open a link** tab runs just the receiver half. Paste any `shlink:`, or open a viewer-prefixed link, which fills it in and runs automatically.
 
 > The viewer's **Start check** calls an unauthenticated demo route (`POST /demo/kickoff`) on the app so the browser holds no Aidbox credentials. In production, kickoff is the authenticated `shl-kickoff` operation triggered by a back-office service.
 
@@ -162,7 +178,7 @@ GET /shl-app/file/{fileId}    # returns the JWE as application/jose
 
 #### 3. Decrypt the result
 
-In the browser, use the viewer above. In code, the `shlink:` payload (base64url JSON) contains the `key` — decode it and decrypt the JWE with AES-256-GCM:
+In the browser, use the viewer above. In code, the `shlink:` payload (base64url JSON) contains the `key`. Decode it and decrypt the JWE with AES-256-GCM:
 
 ```ts
 import { decodeShlink } from "./src/utils/shl-encode.ts";
@@ -173,7 +189,7 @@ const fhir = JSON.parse(await decryptJwe(jwe, payload.key));
 // -> CoverageEligibilityResponse
 ```
 
-Only the `key` from the `shlink:` decrypts the file. Without it, the ciphertext is unreadable — which is how the result stays private to the client that started the job.
+Only the `key` from the `shlink:` decrypts the file. Without it the ciphertext is unreadable, so the result stays private to the client that started the job.
 
 ## Project layout
 
@@ -200,16 +216,16 @@ src/
 
 ## Protocol hardening
 
-Beyond the happy path, the example implements the security-sensitive plumbing of the SHL spec — the parts you don't want every integrator reimplementing:
+The example also implements the security-sensitive plumbing of the SHL spec, the parts you don't want every integrator reimplementing:
 
-- **Passcode (`P` flag)** — pass a `passcode` to kickoff and the link carries `flag: "LP"`. The manifest then requires it: a missing one returns `401 { "message": "Passcode required" }`, a wrong one returns `401 { "remainingAttempts": N }`. The attempt counter is a **lifetime** total persisted on the `SHLink` (and decremented before responding), so it holds up against parallel guessing. Once it hits zero the link locks — even the correct passcode then resolves to `no-longer-valid`.
-- **Short-lived `location` URLs** — when the manifest hands back a `location` instead of an `embedded` file, it mints a per-request token with an expiry (`SHL_FILE_TOKEN_TTL_SECONDS`, default 60s; the spec allows ≤ 1 hour). Fetching after it expires returns `410 Gone`.
-- **Poll throttling** — polling one link's manifest faster than `SHL_MANIFEST_MIN_INTERVAL_SECONDS` returns `429` with a `Retry-After` header; the viewer honors it.
+- **Passcode (`P` flag)**: pass a `passcode` to kickoff and the link carries `flag: "LP"`. The manifest then requires it. A missing one returns `401 { "message": "Passcode required" }`, a wrong one returns `401 { "remainingAttempts": N }`. The attempt counter is a **lifetime** total persisted on the `SHLink` (and decremented before responding), so it holds up against parallel guessing. Once it hits zero the link locks, and even the correct passcode then resolves to `no-longer-valid`.
+- **Short-lived `location` URLs**: when the manifest hands back a `location` instead of an `embedded` file, it mints a per-request token with an expiry (`SHL_FILE_TOKEN_TTL_SECONDS`, default 60s; the spec allows ≤ 1 hour). Fetching after it expires returns `410 Gone`.
+- **Poll throttling**: polling one link's manifest faster than `SHL_MANIFEST_MIN_INTERVAL_SECONDS` returns `429` with a `Retry-After` header, which the viewer honors.
 
 Tunable via env (see `.env.example`): `SHL_PASSCODE_MAX_ATTEMPTS`, `SHL_FILE_TOKEN_TTL_SECONDS`, `SHL_MANIFEST_MIN_INTERVAL_SECONDS`.
 
 ## Notes & scope
 
-- **Flags**: uses `L` (long-term, since the manifest evolves pending → ready) and optionally `P` (passcode). It does not implement `U` (direct file) — see the SHL spec.
-- **Key storage**: the SHL key is persisted on the `SHLink` resource so the background worker can encrypt the result once the RTE job finishes. In production you'd avoid long-term key storage (hold it only in the worker, or encrypt-on-write and discard) — this is the one deliberate simplification, flagged because it's the central security tradeoff of the design.
+- **Flags**: uses `L` (long-term, since the manifest evolves pending → ready) and optionally `P` (passcode). It does not implement `U` (direct file); see the SHL spec.
+- **Key storage**: the SHL key is persisted on the `SHLink` resource so the background worker can encrypt the result once the RTE job finishes. In production you'd avoid long-term key storage (hold it only in the worker, or encrypt-on-write and discard). This is the one deliberate simplification, called out because it's the central security tradeoff of the design.
 - **Out of scope**: real payer RTE (270/271) integration, `location` single-use enforcement (only expiry is enforced here), key rotation.

--- a/aidbox-integrations/smart-health-link/bun.lock
+++ b/aidbox-integrations/smart-health-link/bun.lock
@@ -1,0 +1,298 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "aidbox-smart-health-link",
+      "dependencies": {
+        "@health-samurai/aidbox-client": "^0.0.0-alpha.4",
+        "jose": "^5.2.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.1.0",
+        "@typescript-eslint/eslint-plugin": "^6.20.0",
+        "@typescript-eslint/parser": "^6.20.0",
+        "eslint": "^8.56.0",
+        "prettier": "^3.2.5",
+        "typescript": "^5.3.3",
+      },
+    },
+  },
+  "packages": {
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@2.1.4", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^9.6.0", "globals": "^13.19.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.0", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ=="],
+
+    "@eslint/js": ["@eslint/js@8.57.1", "", {}, "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="],
+
+    "@health-samurai/aidbox-client": ["@health-samurai/aidbox-client@0.0.0-alpha.7", "", { "dependencies": { "@types/json-patch": "^0.0.33", "oauth4webapi": "^3.8.5", "yaml": "^2.8.3" } }, "sha512-mXO3t+6nyCUUeN03zs+1+PtatstjwlB2zPVLBrYL43ONiCnCvTeD6UHyJV96VH6eQaeMoBgzx53VvWsLPZOo8A=="],
+
+    "@humanwhocodes/config-array": ["@humanwhocodes/config-array@0.13.0", "", { "dependencies": { "@humanwhocodes/object-schema": "^2.0.3", "debug": "^4.3.1", "minimatch": "^3.0.5" } }, "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/object-schema": ["@humanwhocodes/object-schema@2.0.3", "", {}, "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/json-patch": ["@types/json-patch@0.0.33", "", {}, "sha512-XQ9hIoJCtnvTCnIV+p+SWQbY8Bt1pe+RuTkPG7lQeRCa9sPwYbhb0aYzM2paVPk0SGvV70R33rxjPjBcJ4Kdxw=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/node": ["@types/node@26.0.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA=="],
+
+    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@6.21.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.5.1", "@typescript-eslint/scope-manager": "6.21.0", "@typescript-eslint/type-utils": "6.21.0", "@typescript-eslint/utils": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0", "debug": "^4.3.4", "graphemer": "^1.4.0", "ignore": "^5.2.4", "natural-compare": "^1.4.0", "semver": "^7.5.4", "ts-api-utils": "^1.0.1" }, "peerDependencies": { "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha", "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@6.21.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "6.21.0", "@typescript-eslint/types": "6.21.0", "@typescript-eslint/typescript-estree": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@6.21.0", "", { "dependencies": { "@typescript-eslint/types": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0" } }, "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@6.21.0", "", { "dependencies": { "@typescript-eslint/typescript-estree": "6.21.0", "@typescript-eslint/utils": "6.21.0", "debug": "^4.3.4", "ts-api-utils": "^1.0.1" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@6.21.0", "", {}, "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@6.21.0", "", { "dependencies": { "@typescript-eslint/types": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0", "debug": "^4.3.4", "globby": "^11.1.0", "is-glob": "^4.0.3", "minimatch": "9.0.3", "semver": "^7.5.4", "ts-api-utils": "^1.0.1" } }, "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@6.21.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.4.0", "@types/json-schema": "^7.0.12", "@types/semver": "^7.5.0", "@typescript-eslint/scope-manager": "6.21.0", "@typescript-eslint/types": "6.21.0", "@typescript-eslint/typescript-estree": "6.21.0", "semver": "^7.5.4" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@6.21.0", "", { "dependencies": { "@typescript-eslint/types": "6.21.0", "eslint-visitor-keys": "^3.4.1" } }, "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.2", "", {}, "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA=="],
+
+    "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
+
+    "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@8.57.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.6.1", "@eslint/eslintrc": "^2.1.4", "@eslint/js": "8.57.1", "@humanwhocodes/config-array": "^0.13.0", "@humanwhocodes/module-importer": "^1.0.1", "@nodelib/fs.walk": "^1.2.8", "@ungap/structured-clone": "^1.2.0", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.2", "debug": "^4.3.2", "doctrine": "^3.0.0", "escape-string-regexp": "^4.0.0", "eslint-scope": "^7.2.2", "eslint-visitor-keys": "^3.4.3", "espree": "^9.6.1", "esquery": "^1.4.2", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^6.0.1", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "globals": "^13.19.0", "graphemer": "^1.4.0", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "is-path-inside": "^3.0.3", "js-yaml": "^4.1.0", "json-stable-stringify-without-jsonify": "^1.0.1", "levn": "^0.4.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3", "strip-ansi": "^6.0.1", "text-table": "^0.2.0" }, "bin": { "eslint": "bin/eslint.js" } }, "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA=="],
+
+    "eslint-scope": ["eslint-scope@7.2.2", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "espree": ["espree@9.6.1", "", { "dependencies": { "acorn": "^8.9.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^3.4.1" } }, "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
+
+    "file-entry-cache": ["file-entry-cache@6.0.1", "", { "dependencies": { "flat-cache": "^3.0.4" } }, "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@3.2.0", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.3", "rimraf": "^3.0.2" } }, "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
+
+    "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@13.24.0", "", { "dependencies": { "type-fest": "^0.20.2" } }, "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ=="],
+
+    "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
+
+    "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-path-inside": ["is-path-inside@3.0.3", "", {}, "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+
+    "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "oauth4webapi": ["oauth4webapi@3.8.6", "", {}, "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
+
+    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@3.8.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "text-table": ["text-table@0.2.0", "", {}, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "ts-api-utils": ["ts-api-utils@1.4.3", "", { "peerDependencies": { "typescript": ">=4.2.0" } }, "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.3", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg=="],
+
+    "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
+  }
+}

--- a/aidbox-integrations/smart-health-link/docker-compose.yaml
+++ b/aidbox-integrations/smart-health-link/docker-compose.yaml
@@ -1,0 +1,100 @@
+volumes:
+  postgres_data: {}
+
+services:
+  postgres:
+    image: postgres:18
+    volumes:
+      - postgres_data:/var/lib/postgresql:delegated
+    command:
+      - postgres
+      - -c
+      - shared_preload_libraries=pg_stat_statements
+    environment:
+      POSTGRES_USER: aidbox
+      POSTGRES_PORT: "5432"
+      POSTGRES_DB: aidbox
+      POSTGRES_PASSWORD: hb1NnSed7w
+
+  aidbox:
+    image: healthsamurai/aidboxone:edge
+    pull_policy: always
+    depends_on:
+      - postgres
+    ports:
+      - 8080:8080
+    volumes:
+      - ./init-bundle:/app/init-bundle:ro
+    environment:
+      BOX_ADMIN_PASSWORD: uN6jhgu8eo
+      BOX_BOOTSTRAP_FHIR_PACKAGES: hl7.fhir.r4.core#4.0.1
+      BOX_COMPATIBILITY_VALIDATION_JSON__SCHEMA_REGEX: "#{:fhir-datetime}"
+      BOX_DB_DATABASE: aidbox
+      BOX_DB_HOST: postgres
+      BOX_DB_PASSWORD: hb1NnSed7w
+      BOX_DB_PORT: "5432"
+      BOX_DB_USER: aidbox
+      BOX_FHIR_COMPLIANT_MODE: true
+      BOX_FHIR_CORRECT_AIDBOX_FORMAT: true
+      BOX_FHIR_CREATEDAT_URL: https://aidbox.app/ex/createdAt
+      BOX_FHIR_SCHEMA_VALIDATION: true
+      BOX_FHIR_SEARCH_AUTHORIZE_INLINE_REQUESTS: true
+      BOX_FHIR_SEARCH_CHAIN_SUBSELECT: true
+      BOX_FHIR_SEARCH_COMPARISONS: true
+      BOX_FHIR_TERMINOLOGY_ENGINE: hybrid
+      BOX_FHIR_TERMINOLOGY_ENGINE_HYBRID_EXTERNAL_TX_SERVER: https://tx.health-samurai.io/fhir
+      BOX_FHIR_TERMINOLOGY_SERVICE_BASE_URL: https://tx.health-samurai.io/fhir
+      BOX_MODULE_SDC_STRICT_ACCESS_CONTROL: true
+      BOX_ROOT_CLIENT_SECRET: qNbQS6sw82
+      BOX_RUNME_UUID: 7c429b2a-14af-4859-ae12-7e23e46be07d
+      BOX_SEARCH_INCLUDE_CONFORMANT: true
+      BOX_SECURITY_AUDIT_LOG_ENABLED: true
+      BOX_SECURITY_DEV_MODE: true
+      BOX_SETTINGS_MODE: read-write
+      BOX_WEB_BASE_URL: http://localhost:8080
+      BOX_WEB_PORT: 8080
+      BOX_INIT_BUNDLE: file:///app/init-bundle/bundle.json
+    healthcheck:
+      test: curl -f http://localhost:8080/health || exit 1
+      interval: 5s
+      timeout: 5s
+      retries: 90
+      start_period: 30s
+
+  shl-app:
+    build: .
+    ports:
+      - 3000:3000
+    depends_on:
+      aidbox:
+        condition: service_healthy
+    environment:
+      PORT: 3000
+      NODE_ENV: production
+
+      # Aidbox FHIR API access (Basic auth client from the init bundle).
+      # Bare host — the Aidbox client appends /fhir itself.
+      AIDBOX_BASE_URL: http://aidbox:8080
+      AIDBOX_CLIENT_ID: shl-client
+      AIDBOX_CLIENT_SECRET: secret
+
+      # Public base URL of the SHL endpoints, as the receiver reaches them
+      # (operations are proxied through Aidbox under /shl-app/...).
+      SHL_PUBLIC_BASE_URL: http://localhost:8080/shl-app
+      # Minted shlink: values are prefixed so they open the in-app viewer with
+      # the link prefilled (the viewer reads it from the URL fragment).
+      SHL_VIEWER_URL: "http://localhost:3000/#"
+
+      # Simulated real-time eligibility processing delay
+      RTE_PROCESSING_SECONDS: 10
+
+      # SHL protocol policy (passcode attempts, location TTL, poll throttle)
+      SHL_PASSCODE_MAX_ATTEMPTS: 5
+      SHL_FILE_TOKEN_TTL_SECONDS: 60
+      SHL_MANIFEST_MIN_INTERVAL_SECONDS: 1
+    healthcheck:
+      test: curl -f http://localhost:3000/health || exit 1
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s

--- a/aidbox-integrations/smart-health-link/eslint.config.cjs
+++ b/aidbox-integrations/smart-health-link/eslint.config.cjs
@@ -1,0 +1,24 @@
+module.exports = [
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parser: require('@typescript-eslint/parser'),
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+        project: './tsconfig.json'
+      }
+    },
+    plugins: {
+      '@typescript-eslint': require('@typescript-eslint/eslint-plugin')
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'warn',
+      '@typescript-eslint/no-explicit-any': 'warn',
+      'no-console': 'warn',
+      'prefer-const': 'error',
+      'no-var': 'error'
+    }
+  }
+];

--- a/aidbox-integrations/smart-health-link/init-bundle/bundle.json
+++ b/aidbox-integrations/smart-health-link/init-bundle/bundle.json
@@ -1,0 +1,114 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Client",
+        "id": "shl-client",
+        "secret": "secret",
+        "grant_types": ["basic"]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Client/shl-client"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "AccessPolicy",
+        "id": "shl-client-policy",
+        "engine": "allow",
+        "link": [
+          {
+            "id": "shl-client",
+            "resourceType": "Client"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "AccessPolicy/shl-client-policy"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "StructureDefinition",
+        "id": "SHLink",
+        "url": "http://example.org/fhir/StructureDefinition/SHLink",
+        "name": "SHLink",
+        "status": "active",
+        "kind": "resource",
+        "abstract": false,
+        "type": "SHLink",
+        "baseDefinition": "http://hl7.org/fhir/StructureDefinition/DomainResource",
+        "derivation": "specialization",
+        "differential": {
+          "element": [
+            { "id": "SHLink", "path": "SHLink", "min": 0, "max": "*" },
+            { "id": "SHLink.key", "path": "SHLink.key", "min": 1, "max": "1", "type": [{ "code": "string" }] },
+            { "id": "SHLink.label", "path": "SHLink.label", "min": 1, "max": "1", "type": [{ "code": "string" }] },
+            { "id": "SHLink.jobStatus", "path": "SHLink.jobStatus", "min": 1, "max": "1", "type": [{ "code": "code" }] },
+            { "id": "SHLink.contentType", "path": "SHLink.contentType", "min": 0, "max": "1", "type": [{ "code": "string" }] },
+            { "id": "SHLink.sourceRef", "path": "SHLink.sourceRef", "min": 0, "max": "1", "type": [{ "code": "string" }] },
+            { "id": "SHLink.encryptedFile", "path": "SHLink.encryptedFile", "min": 0, "max": "1", "type": [{ "code": "string" }] },
+            { "id": "SHLink.exp", "path": "SHLink.exp", "min": 0, "max": "1", "type": [{ "code": "integer" }] },
+            { "id": "SHLink.passcode", "path": "SHLink.passcode", "min": 0, "max": "1", "type": [{ "code": "string" }] },
+            { "id": "SHLink.remainingAttempts", "path": "SHLink.remainingAttempts", "min": 0, "max": "1", "type": [{ "code": "integer" }] },
+            { "id": "SHLink.lastManifestAtMs", "path": "SHLink.lastManifestAtMs", "min": 0, "max": "1", "type": [{ "code": "decimal" }] },
+            { "id": "SHLink.fileTokens", "path": "SHLink.fileTokens", "min": 0, "max": "*", "type": [{ "code": "BackboneElement" }] },
+            { "id": "SHLink.fileTokens.token", "path": "SHLink.fileTokens.token", "min": 1, "max": "1", "type": [{ "code": "string" }] },
+            { "id": "SHLink.fileTokens.expiresAtMs", "path": "SHLink.fileTokens.expiresAtMs", "min": 1, "max": "1", "type": [{ "code": "decimal" }] }
+          ]
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "StructureDefinition/SHLink"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "App",
+        "id": "shl-app",
+        "type": "app",
+        "apiVersion": 1,
+        "endpoint": {
+          "type": "http-rpc",
+          "url": "http://shl-app:3000/shl-app",
+          "secret": "shl-app-secret"
+        },
+        "operations": {
+          "shl-kickoff": {
+            "method": "POST",
+            "path": ["shl-app", "eligibility", "$kickoff"]
+          },
+          "shl-manifest": {
+            "method": "POST",
+            "path": ["shl-app", "manifest", { "name": "shlId" }],
+            "policies": {
+              "shl-manifest-public": { "engine": "allow" }
+            }
+          },
+          "shl-file": {
+            "method": "GET",
+            "path": ["shl-app", "file", { "name": "fileId" }],
+            "policies": {
+              "shl-file-public": { "engine": "allow" }
+            }
+          }
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "App/shl-app"
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "$drop-cache"
+      }
+    }
+  ]
+}

--- a/aidbox-integrations/smart-health-link/init-bundle/bundle.json
+++ b/aidbox-integrations/smart-health-link/init-bundle/bundle.json
@@ -45,20 +45,20 @@
         "derivation": "specialization",
         "differential": {
           "element": [
-            { "id": "SHLink", "path": "SHLink", "min": 0, "max": "*" },
-            { "id": "SHLink.key", "path": "SHLink.key", "min": 1, "max": "1", "type": [{ "code": "string" }] },
-            { "id": "SHLink.label", "path": "SHLink.label", "min": 1, "max": "1", "type": [{ "code": "string" }] },
-            { "id": "SHLink.jobStatus", "path": "SHLink.jobStatus", "min": 1, "max": "1", "type": [{ "code": "code" }] },
-            { "id": "SHLink.contentType", "path": "SHLink.contentType", "min": 0, "max": "1", "type": [{ "code": "string" }] },
-            { "id": "SHLink.sourceRef", "path": "SHLink.sourceRef", "min": 0, "max": "1", "type": [{ "code": "string" }] },
-            { "id": "SHLink.encryptedFile", "path": "SHLink.encryptedFile", "min": 0, "max": "1", "type": [{ "code": "string" }] },
-            { "id": "SHLink.exp", "path": "SHLink.exp", "min": 0, "max": "1", "type": [{ "code": "integer" }] },
-            { "id": "SHLink.passcode", "path": "SHLink.passcode", "min": 0, "max": "1", "type": [{ "code": "string" }] },
-            { "id": "SHLink.remainingAttempts", "path": "SHLink.remainingAttempts", "min": 0, "max": "1", "type": [{ "code": "integer" }] },
-            { "id": "SHLink.lastManifestAtMs", "path": "SHLink.lastManifestAtMs", "min": 0, "max": "1", "type": [{ "code": "decimal" }] },
-            { "id": "SHLink.fileTokens", "path": "SHLink.fileTokens", "min": 0, "max": "*", "type": [{ "code": "BackboneElement" }] },
-            { "id": "SHLink.fileTokens.token", "path": "SHLink.fileTokens.token", "min": 1, "max": "1", "type": [{ "code": "string" }] },
-            { "id": "SHLink.fileTokens.expiresAtMs", "path": "SHLink.fileTokens.expiresAtMs", "min": 1, "max": "1", "type": [{ "code": "decimal" }] }
+            { "id": "SHLink", "path": "SHLink", "min": 0, "max": "*", "short": "A SMART Health Link", "definition": "Server-side state for one SMART Health Link (SHL): the encryption key, the encrypted payload, and the protocol bookkeeping (passcode, expiry, throttling, file tokens) needed to resolve it." },
+            { "id": "SHLink.key", "path": "SHLink.key", "min": 1, "max": "1", "type": [{ "code": "string" }], "short": "Content-encryption key", "definition": "The base64url-encoded 256-bit AES key that encrypts this link's file. It also travels inside the shlink: URI, so only the holder of the link can decrypt the result. The server stores it here only so the background worker can encrypt the result once the job finishes." },
+            { "id": "SHLink.label", "path": "SHLink.label", "min": 1, "max": "1", "type": [{ "code": "string" }], "short": "Human-readable label", "definition": "Short description of what the link carries, shown to the receiver (e.g. \"Eligibility result for Jane Prospect\")." },
+            { "id": "SHLink.jobStatus", "path": "SHLink.jobStatus", "min": 1, "max": "1", "type": [{ "code": "code" }], "short": "Async job lifecycle: pending | ready", "definition": "Lifecycle of the content-producing job. 'pending' while the (long-running) job is in flight — the manifest reports 'can-change'; 'ready' once the encrypted file is attached — the manifest reports 'finalized'." },
+            { "id": "SHLink.contentType", "path": "SHLink.contentType", "min": 0, "max": "1", "type": [{ "code": "string" }], "short": "MIME type of the decrypted file", "definition": "Content type of the payload after decryption, reported in the manifest (e.g. 'application/fhir+json' for a CoverageEligibilityResponse)." },
+            { "id": "SHLink.sourceRef", "path": "SHLink.sourceRef", "min": 0, "max": "1", "type": [{ "code": "string" }], "short": "Reference to the source FHIR resource", "definition": "Reference to the FHIR resource the encrypted content was produced from (e.g. 'CoverageEligibilityResponse/123'), for traceability." },
+            { "id": "SHLink.encryptedFile", "path": "SHLink.encryptedFile", "min": 0, "max": "1", "type": [{ "code": "string" }], "short": "Encrypted payload (JWE)", "definition": "The link's content encrypted as a JWE compact serialization (alg 'dir', enc 'A256GCM') under SHLink.key. This is the only form of the content the server stores or serves; it is set when the job becomes 'ready'." },
+            { "id": "SHLink.exp", "path": "SHLink.exp", "min": 0, "max": "1", "type": [{ "code": "integer" }], "short": "Expiration (epoch seconds)", "definition": "Optional absolute expiry as a Unix timestamp in seconds. After this moment the link resolves to 'no-longer-valid' and file fetches return 410 Gone." },
+            { "id": "SHLink.passcode", "path": "SHLink.passcode", "min": 0, "max": "1", "type": [{ "code": "string" }], "short": "Optional passcode (P flag)", "definition": "When set, the link carries the 'P' flag and the manifest requires this passcode (delivered out-of-band, never inside the shlink:) to resolve. A second secret guarding against link interception." },
+            { "id": "SHLink.remainingAttempts", "path": "SHLink.remainingAttempts", "min": 0, "max": "1", "type": [{ "code": "integer" }], "short": "Remaining passcode attempts", "definition": "Lifetime count of incorrect-passcode attempts left before the link locks permanently. Decremented (and persisted) before responding, so parallel guesses cannot bypass the limit." },
+            { "id": "SHLink.lastManifestAtMs", "path": "SHLink.lastManifestAtMs", "min": 0, "max": "1", "type": [{ "code": "decimal" }], "short": "Last manifest poll (epoch ms)", "definition": "Timestamp of the most recent successful manifest poll, in milliseconds. Used to throttle frequent polling of the same link (429 + Retry-After)." },
+            { "id": "SHLink.fileTokens", "path": "SHLink.fileTokens", "min": 0, "max": "*", "type": [{ "code": "BackboneElement" }], "short": "Short-lived file-location tokens", "definition": "Tokens minted when the manifest returns a 'location' URL (instead of embedding the file). Each grants a short, time-bounded fetch of the encrypted file." },
+            { "id": "SHLink.fileTokens.token", "path": "SHLink.fileTokens.token", "min": 1, "max": "1", "type": [{ "code": "string" }], "short": "Opaque file token", "definition": "The token value, of the form '<shlId>~<random>', embedded in the manifest's 'location' URL so the file endpoint can resolve the link without a custom search parameter." },
+            { "id": "SHLink.fileTokens.expiresAtMs", "path": "SHLink.fileTokens.expiresAtMs", "min": 1, "max": "1", "type": [{ "code": "decimal" }], "short": "Token expiry (epoch ms)", "definition": "Absolute expiry of the file token in milliseconds. After it, fetching the location returns 410 Gone." }
           ]
         }
       },
@@ -102,12 +102,6 @@
       "request": {
         "method": "PUT",
         "url": "App/shl-app"
-      }
-    },
-    {
-      "request": {
-        "method": "POST",
-        "url": "$drop-cache"
       }
     }
   ]

--- a/aidbox-integrations/smart-health-link/package.json
+++ b/aidbox-integrations/smart-health-link/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "aidbox-smart-health-link",
+  "version": "1.0.0",
+  "description": "SMART Health Links sharing of an async eligibility (RTE) result, integrated with Aidbox",
+  "module": "src/server.ts",
+  "type": "module",
+  "scripts": {
+    "dev": "bun --watch src/server.ts",
+    "start": "bun src/server.ts",
+    "lint": "eslint src/**/*.ts --fix"
+  },
+  "keywords": [
+    "fhir",
+    "smart-health-links",
+    "aidbox",
+    "jwe",
+    "typescript",
+    "bun"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@health-samurai/aidbox-client": "^0.0.0-alpha.4",
+    "jose": "^5.2.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.1.0",
+    "@typescript-eslint/eslint-plugin": "^6.20.0",
+    "@typescript-eslint/parser": "^6.20.0",
+    "eslint": "^8.56.0",
+    "prettier": "^3.2.5",
+    "typescript": "^5.3.3"
+  }
+}

--- a/aidbox-integrations/smart-health-link/src/handlers/shl.ts
+++ b/aidbox-integrations/smart-health-link/src/handlers/shl.ts
@@ -48,6 +48,8 @@ export class ShlHandler {
       payerName,
       memberId: memberId ?? 'unknown',
       passcode: params.passcode,
+      // Optional demo control: pass eligible=false to synthesize a not-eligible result.
+      eligible: params.eligible !== 'false',
     });
 
     return json({

--- a/aidbox-integrations/smart-health-link/src/handlers/shl.ts
+++ b/aidbox-integrations/smart-health-link/src/handlers/shl.ts
@@ -1,0 +1,133 @@
+import type { AidboxOperationRequest, ManifestRequestBody } from '../types/operation.ts';
+import type { ShlService } from '../services/shl-service.ts';
+import type { EligibilityWorkflow } from '../services/eligibility-workflow.ts';
+
+/** JSON Response helper. */
+function json(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+function operationOutcome(severity: string, code: string, text: string, status: number): Response {
+  return json(
+    { resourceType: 'OperationOutcome', issue: [{ severity, code, details: { text } }] },
+    status
+  );
+}
+
+/**
+ * Handles the three Aidbox App operations behind the SMART Health Links flow.
+ * Each method maps one `operation.id` configured in the init bundle.
+ */
+export class ShlHandler {
+  constructor(
+    private readonly shl: ShlService,
+    private readonly workflow: EligibilityWorkflow
+  ) {}
+
+  /** operation `shl-kickoff`: start an RTE job and mint a shlink: (App-layer use case). */
+  async handleKickoff(op: AidboxOperationRequest): Promise<Response> {
+    const params = extractParameters(op.request.resource);
+    const memberName = params.memberName;
+    const payerName = params.payerName;
+    const memberId = params.memberId;
+
+    if (!memberName || !payerName) {
+      return operationOutcome(
+        'error',
+        'invalid',
+        'memberName and payerName parameters are required',
+        400
+      );
+    }
+
+    const result = await this.workflow.kickOff({
+      memberName,
+      payerName,
+      memberId: memberId ?? 'unknown',
+      passcode: params.passcode,
+    });
+
+    return json({
+      resourceType: 'Parameters',
+      parameter: [
+        { name: 'shlinkId', valueString: result.shlinkId },
+        { name: 'shlink', valueString: result.shlink },
+        { name: 'manifestUrl', valueString: result.payload.url },
+      ],
+    });
+  }
+
+  /** operation `shl-manifest`: the SHL receiver POSTs the manifest URL. */
+  async handleManifest(op: AidboxOperationRequest): Promise<Response> {
+    const shlinkId = op.request['route-params'].shlId;
+    if (!shlinkId) {
+      return operationOutcome('error', 'invalid', 'Missing shlId', 400);
+    }
+
+    const body = (op.request.resource ?? {}) as ManifestRequestBody;
+    if (!body.recipient) {
+      return operationOutcome('error', 'invalid', 'recipient is required', 400);
+    }
+
+    const result = await this.shl.getManifest(shlinkId, {
+      embeddedLengthMax: body.embeddedLengthMax,
+      passcode: body.passcode,
+    });
+
+    switch (result.kind) {
+      case 'ok':
+        return json(result.manifest);
+      case 'not-found':
+        return operationOutcome('error', 'not-found', 'Unknown SMART Health Link', 404);
+      case 'passcode-required':
+        // Spec: a passcode is required to resolve this link.
+        return json({ message: 'Passcode required' }, 401);
+      case 'passcode-invalid':
+        // Spec: reject and report remaining lifetime attempts.
+        return json({ remainingAttempts: result.remainingAttempts }, 401);
+      case 'rate-limited':
+        return json({ message: 'Too many requests' }, 429, {
+          'Retry-After': String(result.retryAfterSeconds),
+        });
+    }
+  }
+
+  /** operation `shl-file`: the receiver GETs a short-lived file location. */
+  async handleFile(op: AidboxOperationRequest): Promise<Response> {
+    const token = op.request['route-params'].fileId;
+    if (!token) {
+      return operationOutcome('error', 'invalid', 'Missing file token', 400);
+    }
+
+    const result = await this.shl.getFile(token);
+    switch (result.kind) {
+      case 'ok':
+        // Per spec, file locations return the JWE with content-type application/jose.
+        return new Response(result.jwe, {
+          status: 200,
+          headers: { 'Content-Type': 'application/jose' },
+        });
+      case 'gone':
+        // The short-lived location URL has expired.
+        return operationOutcome('error', 'expired', 'File link has expired', 410);
+      case 'not-found':
+        return operationOutcome('error', 'not-found', 'File not available', 404);
+    }
+  }
+}
+
+/** Pull simple string params out of a FHIR Parameters resource. */
+function extractParameters(resource: unknown): Record<string, string | undefined> {
+  const out: Record<string, string | undefined> = {};
+  const params = (resource as { parameter?: Array<{ name: string; valueString?: string }> })
+    ?.parameter;
+  if (Array.isArray(params)) {
+    for (const p of params) {
+      if (p.valueString !== undefined) out[p.name] = p.valueString;
+    }
+  }
+  return out;
+}

--- a/aidbox-integrations/smart-health-link/src/server.ts
+++ b/aidbox-integrations/smart-health-link/src/server.ts
@@ -1,0 +1,143 @@
+import { loadConfig } from './types/config.ts';
+import type { AidboxOperationRequest } from './types/operation.ts';
+import { FhirClient } from './services/fhir-client.ts';
+import { SHLinkStore } from './services/shlink-store.ts';
+import { EligibilityService } from './services/eligibility.ts';
+import { ShlService } from './services/shl-service.ts';
+import { EligibilityWorkflow } from './services/eligibility-workflow.ts';
+import { ShlHandler } from './handlers/shl.ts';
+
+const config = loadConfig();
+
+// Wire up dependencies.
+// ShlService is the generic SHL protocol engine (would be built into Aidbox).
+// EligibilityWorkflow is the use-case-specific App layer that drives the async job
+// and feeds finished content back to the engine via attachContent().
+const fhir = new FhirClient(config);
+const shlService = new ShlService(config, { store: new SHLinkStore(fhir) });
+const workflow = new EligibilityWorkflow(config, shlService, new EligibilityService(fhir));
+const handler = new ShlHandler(shlService, workflow);
+
+// The browser-based SHL viewer (paste a shlink:, decrypt client-side).
+const viewerHtml = await Bun.file(new URL('./viewer.html', import.meta.url)).text();
+
+/**
+ * Aidbox routes every configured App operation to this single endpoint and
+ * dispatches by `operation.id`. We mirror that pattern here.
+ */
+async function dispatch(op: AidboxOperationRequest): Promise<Response> {
+  switch (op.operation.id) {
+    case 'shl-kickoff':
+      return handler.handleKickoff(op);
+    case 'shl-manifest':
+      return handler.handleManifest(op);
+    case 'shl-file':
+      return handler.handleFile(op);
+    default:
+      return new Response(
+        JSON.stringify({ error: `Unsupported operation: ${op.operation.id}` }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+  }
+}
+
+const server = Bun.serve({
+  port: config.server.port,
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    if (req.method === 'GET' && url.pathname === '/health') {
+      return Response.json({
+        status: 'healthy',
+        service: 'aidbox-smart-health-link',
+        timestamp: new Date().toISOString(),
+      });
+    }
+
+    // SHL viewer page.
+    if (req.method === 'GET' && (url.pathname === '/' || url.pathname === '/viewer')) {
+      return new Response(viewerHtml, {
+        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+      });
+    }
+
+    // Demo-only kickoff for the viewer UI. In production the kickoff is an
+    // authenticated, back-office trigger (the `shl-kickoff` Aidbox operation);
+    // here the app exposes an unauthenticated convenience route so the demo page
+    // can start a check without putting Aidbox credentials in the browser.
+    if (req.method === 'POST' && url.pathname === '/demo/kickoff') {
+      let body: {
+        memberName?: string;
+        payerName?: string;
+        memberId?: string;
+        passcode?: string;
+      };
+      try {
+        body = (await req.json()) as typeof body;
+      } catch {
+        return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+      }
+      if (!body.memberName || !body.payerName) {
+        return Response.json(
+          { error: 'memberName and payerName are required' },
+          { status: 400 }
+        );
+      }
+      try {
+        const result = await workflow.kickOff({
+          memberName: body.memberName,
+          payerName: body.payerName,
+          memberId: body.memberId ?? 'unknown',
+          passcode: body.passcode,
+        });
+        return Response.json({
+          shlinkId: result.shlinkId,
+          shlink: result.shlink,
+          manifestUrl: result.payload.url,
+        });
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('Demo kickoff error:', err);
+        return Response.json({ error: 'Kickoff failed' }, { status: 500 });
+      }
+    }
+
+    // All Aidbox App operations arrive as POST to /shl-app with the operation envelope.
+    if (req.method === 'POST' && url.pathname === '/shl-app') {
+      let op: AidboxOperationRequest;
+      try {
+        op = (await req.json()) as AidboxOperationRequest;
+      } catch {
+        return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      try {
+        return await dispatch(op);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('Operation error:', err);
+        return new Response(
+          JSON.stringify({
+            resourceType: 'OperationOutcome',
+            issue: [{ severity: 'error', code: 'exception', details: { text: 'Internal error' } }],
+          }),
+          { status: 500, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+    }
+
+    return new Response(
+      JSON.stringify({
+        resourceType: 'OperationOutcome',
+        issue: [{ severity: 'error', code: 'not-found', details: { text: 'Not found' } }],
+      }),
+      { status: 404, headers: { 'Content-Type': 'application/json' } }
+    );
+  },
+});
+
+// eslint-disable-next-line no-console
+console.log(`SMART Health Link service listening on port ${server.port}`);

--- a/aidbox-integrations/smart-health-link/src/server.ts
+++ b/aidbox-integrations/smart-health-link/src/server.ts
@@ -71,6 +71,7 @@ const server = Bun.serve({
         payerName?: string;
         memberId?: string;
         passcode?: string;
+        eligible?: boolean;
       };
       try {
         body = (await req.json()) as typeof body;
@@ -89,6 +90,7 @@ const server = Bun.serve({
           payerName: body.payerName,
           memberId: body.memberId ?? 'unknown',
           passcode: body.passcode,
+          eligible: body.eligible,
         });
         return Response.json({
           shlinkId: result.shlinkId,

--- a/aidbox-integrations/smart-health-link/src/services/eligibility-workflow.ts
+++ b/aidbox-integrations/smart-health-link/src/services/eligibility-workflow.ts
@@ -1,0 +1,70 @@
+import type { Config } from '../types/config.ts';
+import type { SHLPayload } from '../types/shl.ts';
+import { ShlService } from './shl-service.ts';
+import { EligibilityService } from './eligibility.ts';
+
+const FHIR_CONTENT_TYPE = 'application/fhir+json';
+
+/**
+ * The application-side (use-case-specific) orchestration.
+ *
+ * This is the part that stays *external* to a built-in SHL service: it knows the
+ * eligibility use case — how to run the (possibly long) RTE job and what content
+ * to produce. It uses the generic protocol engine (ShlService) only through its
+ * seams: mint a link up front, then attach the finished content when the job ends.
+ *
+ *   kickOff() → ShlService.mintLink()            (returns shlink: immediately)
+ *             → runJob() in the background        (produce result, then…)
+ *             → ShlService.attachContent()        (encrypt + finalize the link)
+ */
+export class EligibilityWorkflow {
+  constructor(
+    private readonly config: Config,
+    private readonly shl: ShlService,
+    private readonly eligibility: EligibilityService
+  ) {}
+
+  /**
+   * Start an eligibility check: mint the link, kick off the async job, and return
+   * the shlink: right away. The result is produced and attached in the background.
+   */
+  async kickOff(input: {
+    memberName: string;
+    payerName: string;
+    memberId: string;
+    passcode?: string;
+  }): Promise<{ shlinkId: string; shlink: string; payload: SHLPayload }> {
+    const minted = await this.shl.mintLink({
+      label: `Eligibility result for ${input.memberName}`,
+      passcode: input.passcode,
+    });
+
+    // Run the (simulated) long-running RTE job without blocking the response.
+    void this.runJob(minted.shlinkId, input);
+
+    return minted;
+  }
+
+  private async runJob(
+    shlinkId: string,
+    input: { memberName: string; payerName: string; memberId: string }
+  ): Promise<void> {
+    try {
+      await new Promise((resolve) =>
+        setTimeout(resolve, this.config.rte.processingSeconds * 1000)
+      );
+
+      const { id, resource } = await this.eligibility.produceResult(input);
+
+      // Hand the finished content to the protocol engine, which encrypts + finalizes.
+      await this.shl.attachContent(shlinkId, {
+        bytes: JSON.stringify(resource),
+        contentType: FHIR_CONTENT_TYPE,
+        sourceRef: `CoverageEligibilityResponse/${id}`,
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`RTE job ${shlinkId} failed:`, err);
+    }
+  }
+}

--- a/aidbox-integrations/smart-health-link/src/services/eligibility-workflow.ts
+++ b/aidbox-integrations/smart-health-link/src/services/eligibility-workflow.ts
@@ -33,6 +33,7 @@ export class EligibilityWorkflow {
     payerName: string;
     memberId: string;
     passcode?: string;
+    eligible?: boolean;
   }): Promise<{ shlinkId: string; shlink: string; payload: SHLPayload }> {
     const minted = await this.shl.mintLink({
       label: `Eligibility result for ${input.memberName}`,
@@ -47,7 +48,7 @@ export class EligibilityWorkflow {
 
   private async runJob(
     shlinkId: string,
-    input: { memberName: string; payerName: string; memberId: string }
+    input: { memberName: string; payerName: string; memberId: string; eligible?: boolean }
   ): Promise<void> {
     try {
       await new Promise((resolve) =>

--- a/aidbox-integrations/smart-health-link/src/services/eligibility.ts
+++ b/aidbox-integrations/smart-health-link/src/services/eligibility.ts
@@ -18,10 +18,47 @@ export class EligibilityService {
     memberName: string;
     payerName: string;
     memberId: string;
+    eligible?: boolean;
   }): Promise<{ id: string; resource: Record<string, unknown> }> {
-    // No registered patient or stored Coverage yet — the prospective member is
+    const isEligible = input.eligible !== false;
+    // No registered patient or stored Coverage yet: the prospective member is
     // pre-registration. We carry the coverage and the originating request as
     // contained resources so the response validates while staying self-contained.
+    const insurance = isEligible
+      ? [
+          {
+            coverage: { reference: '#coverage' },
+            inforce: true,
+            item: [
+              {
+                category: {
+                  coding: [
+                    {
+                      system: 'http://terminology.hl7.org/CodeSystem/ex-benefitcategory',
+                      code: '30',
+                      display: 'Health Benefit Plan Coverage',
+                    },
+                  ],
+                },
+                benefit: [
+                  {
+                    type: {
+                      coding: [
+                        {
+                          system: 'http://terminology.hl7.org/CodeSystem/benefit-type',
+                          code: 'copay',
+                          display: 'Copayment per service',
+                        },
+                      ],
+                    },
+                    allowedMoney: { value: 0, currency: 'USD' },
+                  },
+                ],
+              },
+            ],
+          },
+        ]
+      : [{ coverage: { reference: '#coverage' }, inforce: false }];
     const resource: Record<string, unknown> = {
       resourceType: 'CoverageEligibilityResponse',
       status: 'active',
@@ -50,42 +87,11 @@ export class EligibilityService {
       created: new Date().toISOString(),
       request: { reference: '#request' },
       outcome: 'complete',
-      disposition: `Member ${input.memberName} is eligible for services under ${input.payerName}.`,
+      disposition: isEligible
+        ? `Member ${input.memberName} is eligible for services under ${input.payerName}.`
+        : `Member ${input.memberName} is not eligible for services under ${input.payerName}.`,
       insurer: { display: input.payerName },
-      insurance: [
-        {
-          coverage: { reference: '#coverage' },
-          inforce: true,
-          item: [
-            {
-              category: {
-                coding: [
-                  {
-                    system: 'http://terminology.hl7.org/CodeSystem/ex-benefitcategory',
-                    code: '30',
-                    display: 'Health Benefit Plan Coverage',
-                  },
-                ],
-              },
-              benefit: [
-                {
-                  type: {
-                    coding: [
-                      {
-                        system:
-                          'http://terminology.hl7.org/CodeSystem/benefit-type',
-                        code: 'copay',
-                        display: 'Copayment per service',
-                      },
-                    ],
-                  },
-                  allowedMoney: { value: 0, currency: 'USD' },
-                },
-              ],
-            },
-          ],
-        },
-      ],
+      insurance,
     };
 
     const created = await this.fhir.create<{ id: string }>(

--- a/aidbox-integrations/smart-health-link/src/services/eligibility.ts
+++ b/aidbox-integrations/smart-health-link/src/services/eligibility.ts
@@ -1,0 +1,97 @@
+import type { FhirClient } from './fhir-client.ts';
+
+/**
+ * Produces the real-time eligibility (RTE) result.
+ *
+ * In a real deployment this would call out to a payer's RTE endpoint (e.g. an
+ * X12 270/271 transaction) which can take a while to answer. Here we synthesize
+ * a FHIR CoverageEligibilityResponse so the example is self-contained.
+ */
+export class EligibilityService {
+  constructor(private readonly fhir: FhirClient) {}
+
+  /**
+   * Build and persist a CoverageEligibilityResponse representing a successful
+   * eligibility check for the given prospective member.
+   */
+  async produceResult(input: {
+    memberName: string;
+    payerName: string;
+    memberId: string;
+  }): Promise<{ id: string; resource: Record<string, unknown> }> {
+    // No registered patient or stored Coverage yet — the prospective member is
+    // pre-registration. We carry the coverage and the originating request as
+    // contained resources so the response validates while staying self-contained.
+    const resource: Record<string, unknown> = {
+      resourceType: 'CoverageEligibilityResponse',
+      status: 'active',
+      purpose: ['benefits'],
+      contained: [
+        {
+          resourceType: 'Coverage',
+          id: 'coverage',
+          status: 'active',
+          beneficiary: { display: input.memberName },
+          payor: [{ display: input.payerName }],
+          subscriberId: input.memberId,
+        },
+        {
+          resourceType: 'CoverageEligibilityRequest',
+          id: 'request',
+          status: 'active',
+          purpose: ['benefits'],
+          patient: { display: input.memberName },
+          created: new Date().toISOString(),
+          insurer: { display: input.payerName },
+        },
+      ],
+      // No registered patient yet — describe the prospective member inline.
+      patient: { display: input.memberName },
+      created: new Date().toISOString(),
+      request: { reference: '#request' },
+      outcome: 'complete',
+      disposition: `Member ${input.memberName} is eligible for services under ${input.payerName}.`,
+      insurer: { display: input.payerName },
+      insurance: [
+        {
+          coverage: { reference: '#coverage' },
+          inforce: true,
+          item: [
+            {
+              category: {
+                coding: [
+                  {
+                    system: 'http://terminology.hl7.org/CodeSystem/ex-benefitcategory',
+                    code: '30',
+                    display: 'Health Benefit Plan Coverage',
+                  },
+                ],
+              },
+              benefit: [
+                {
+                  type: {
+                    coding: [
+                      {
+                        system:
+                          'http://terminology.hl7.org/CodeSystem/benefit-type',
+                        code: 'copay',
+                        display: 'Copayment per service',
+                      },
+                    ],
+                  },
+                  allowedMoney: { value: 0, currency: 'USD' },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const created = await this.fhir.create<{ id: string }>(
+      'CoverageEligibilityResponse',
+      resource
+    );
+    return { id: created.id, resource: { ...resource, id: created.id } };
+  }
+}

--- a/aidbox-integrations/smart-health-link/src/services/fhir-client.ts
+++ b/aidbox-integrations/smart-health-link/src/services/fhir-client.ts
@@ -1,0 +1,63 @@
+import { AidboxClient, BasicAuthProvider } from '@health-samurai/aidbox-client';
+import type { AuthProvider } from '@health-samurai/aidbox-client';
+import type { Config } from '../types/config.ts';
+
+/**
+ * Thin wrapper over the official Aidbox TypeScript client
+ * (@health-samurai/aidbox-client). Uses Basic auth with the `shl-client`
+ * registered in the init bundle.
+ *
+ * The client returns a `Result` (Ok | Err) rather than throwing on FHIR errors;
+ * we surface that as a thrown Error for create/update and as `null` for a
+ * missing read.
+ */
+export class FhirClient {
+  private readonly client: AidboxClient;
+
+  constructor(config: Config) {
+    // The client prepends "/fhir" itself, so baseUrl must be the bare host.
+    const baseUrl = config.aidbox.baseUrl;
+    // BasicAuthProvider satisfies AuthProvider at runtime; the cast bridges a
+    // typing quirk where AuthProvider.fetch demands the full global fetch type.
+    const auth = new BasicAuthProvider(
+      baseUrl,
+      config.aidbox.clientId,
+      config.aidbox.clientSecret
+    ) as unknown as AuthProvider;
+    this.client = new AidboxClient(baseUrl, auth);
+  }
+
+  /** Create a resource, letting Aidbox assign the id. */
+  async create<T>(resourceType: string, resource: object): Promise<T> {
+    const result = await this.client.create<T>({ type: resourceType, resource: resource as T });
+    if (result.isErr()) {
+      throw new Error(
+        `Aidbox create ${resourceType} failed: ${JSON.stringify(result.value.resource)}`
+      );
+    }
+    return result.value.resource;
+  }
+
+  /** Upsert a resource at a known id. */
+  async put<T>(resourceType: string, id: string, resource: object): Promise<T> {
+    const result = await this.client.update<T>({ type: resourceType, id, resource: resource as T });
+    if (result.isErr()) {
+      throw new Error(
+        `Aidbox update ${resourceType}/${id} failed: ${JSON.stringify(result.value.resource)}`
+      );
+    }
+    return result.value.resource;
+  }
+
+  /** Read a resource by id. Returns null if it does not exist. */
+  async read<T>(resourceType: string, id: string): Promise<T | null> {
+    const result = await this.client.read<T>({ type: resourceType, id });
+    if (result.isErr()) {
+      if (result.value.response.status === 404) return null;
+      throw new Error(
+        `Aidbox read ${resourceType}/${id} failed: ${JSON.stringify(result.value.resource)}`
+      );
+    }
+    return result.value.resource;
+  }
+}

--- a/aidbox-integrations/smart-health-link/src/services/shl-service.ts
+++ b/aidbox-integrations/smart-health-link/src/services/shl-service.ts
@@ -1,0 +1,226 @@
+import type { Config } from '../types/config.ts';
+import type { ManifestResponse, SHLPayload, SHLFileContentType } from '../types/shl.ts';
+import type { SHLinkResource, FileToken } from '../types/shlink-resource.ts';
+import { SHLinkStore } from './shlink-store.ts';
+import { encryptToJwe, generateShlKey } from '../utils/crypto.ts';
+import { encodeShlink } from '../utils/shl-encode.ts';
+
+/** Discriminated outcome of a manifest request, so the handler can pick the HTTP status. */
+export type ManifestResult =
+  | { kind: 'ok'; manifest: ManifestResponse }
+  | { kind: 'not-found' }
+  | { kind: 'passcode-required' }
+  | { kind: 'passcode-invalid'; remainingAttempts: number }
+  | { kind: 'rate-limited'; retryAfterSeconds: number };
+
+/** Discriminated outcome of a file (location) fetch. */
+export type FileResult =
+  | { kind: 'ok'; jwe: string }
+  | { kind: 'not-found' }
+  | { kind: 'gone' }; // expired token
+
+/**
+ * The generic SMART Health Links protocol engine — content-agnostic.
+ *
+ * This is the layer that a built-in Aidbox SHL service would own: it knows the
+ * protocol and the security plumbing, but nothing about *what* a link carries or
+ * *how* that content is produced. It exposes:
+ *   - mintLink()      — create a pending link, return the shlink:
+ *   - attachContent() — encrypt finished bytes under the link's key and finalize
+ *                       (the seam an external producer calls when its job is done)
+ *   - getManifest() / getFile() — the receiver-facing protocol
+ *
+ * Security plumbing it owns:
+ *   - the P (passcode) flag with a *lifetime* incorrect-attempt counter (→ 401
+ *     { remainingAttempts }, lock at zero), persisted so parallel requests can't bypass it;
+ *   - short-lived `location` file tokens with an expiry (→ 410 Gone);
+ *   - per-link manifest poll throttling (→ 429 + Retry-After).
+ */
+export class ShlService {
+  private readonly store: SHLinkStore;
+
+  constructor(
+    private readonly config: Config,
+    deps: { store: SHLinkStore }
+  ) {
+    this.store = deps.store;
+  }
+
+  /**
+   * Mint a pending SMART Health Link. Content is attached later via attachContent().
+   * If `passcode` is provided, the link carries the P flag and the manifest is gated.
+   */
+  async mintLink(input: {
+    label: string;
+    passcode?: string;
+  }): Promise<{ shlinkId: string; shlink: string; payload: SHLPayload }> {
+    const key = generateShlKey();
+    const passcode = input.passcode?.trim() || undefined;
+
+    const shlink = await this.store.create({
+      key,
+      label: input.label,
+      jobStatus: 'pending',
+      ...(passcode
+        ? { passcode, remainingAttempts: this.config.shlPolicy.passcodeMaxAttempts }
+        : {}),
+    });
+
+    return {
+      shlinkId: shlink.id!,
+      shlink: this.buildShlinkUri(shlink),
+      payload: this.buildPayload(shlink),
+    };
+  }
+
+  /**
+   * Attach finished content to a link: encrypt it under the link's key and mark
+   * the link `ready`. This is the seam an external content producer calls when
+   * its (possibly long-running) job completes. The producer hands over plaintext
+   * bytes; the protocol engine owns the encryption.
+   */
+  async attachContent(
+    shlinkId: string,
+    content: { bytes: string; contentType: string; sourceRef?: string }
+  ): Promise<void> {
+    const shlink = await this.store.get(shlinkId);
+    if (!shlink) throw new Error(`SHLink ${shlinkId} not found`);
+
+    const jwe = await encryptToJwe(content.bytes, shlink.key, content.contentType);
+    await this.store.save({
+      ...shlink,
+      jobStatus: 'ready',
+      contentType: content.contentType,
+      sourceRef: content.sourceRef,
+      encryptedFile: jwe,
+    });
+  }
+
+  /** Resolve a manifest request, enforcing throttle + passcode and minting file tokens. */
+  async getManifest(
+    shlinkId: string,
+    opts: { embeddedLengthMax?: number; passcode?: string } = {}
+  ): Promise<ManifestResult> {
+    const shlink = await this.store.get(shlinkId);
+    if (!shlink) return { kind: 'not-found' };
+
+    // --- 429: throttle frequent polls of the same link ---
+    const nowMs = Date.now();
+    const minMs = this.config.shlPolicy.manifestMinIntervalSeconds * 1000;
+    if (shlink.lastManifestAtMs && nowMs - shlink.lastManifestAtMs < minMs) {
+      const retryAfterSeconds = Math.ceil((minMs - (nowMs - shlink.lastManifestAtMs)) / 1000);
+      return { kind: 'rate-limited', retryAfterSeconds: Math.max(1, retryAfterSeconds) };
+    }
+
+    // --- passcode (P flag) ---
+    if (shlink.passcode) {
+      if (!opts.passcode) return { kind: 'passcode-required' };
+      if (opts.passcode !== shlink.passcode) {
+        // Lifetime attempt counting: decrement and persist before responding, so
+        // parallel requests can't each spend the "last" attempt.
+        const remaining = Math.max(0, (shlink.remainingAttempts ?? 0) - 1);
+        await this.store.save({ ...shlink, remainingAttempts: remaining, lastManifestAtMs: nowMs });
+        return { kind: 'passcode-invalid', remainingAttempts: remaining };
+      }
+    }
+
+    // Record this (successful-auth) poll for throttling.
+    let current: SHLinkResource = { ...shlink, lastManifestAtMs: nowMs };
+
+    if (this.isExpired(current)) {
+      await this.store.save(current);
+      return { kind: 'ok', manifest: { status: 'no-longer-valid', files: [] } };
+    }
+
+    // A passcode-locked link (no attempts left) is no longer resolvable.
+    if (current.passcode && (current.remainingAttempts ?? 0) <= 0) {
+      await this.store.save(current);
+      return { kind: 'ok', manifest: { status: 'no-longer-valid', files: [] } };
+    }
+
+    // Job still running: long-term (L) link, contents will change.
+    if (current.jobStatus !== 'ready' || !current.encryptedFile) {
+      await this.store.save(current);
+      return { kind: 'ok', manifest: { status: 'can-change', files: [] } };
+    }
+
+    // Ready: embed if allowed, else mint a short-lived location token.
+    const jwe = current.encryptedFile;
+    const canEmbed =
+      opts.embeddedLengthMax === undefined || jwe.length <= opts.embeddedLengthMax;
+    // The link records what it carries (set by attachContent) — report that.
+    const contentType = (current.contentType ??
+      'application/fhir+json') as SHLFileContentType;
+
+    let manifest: ManifestResponse;
+    if (canEmbed) {
+      manifest = { status: 'finalized', files: [{ contentType, embedded: jwe }] };
+    } else {
+      const fileToken = this.mintFileToken(current.id!);
+      current = { ...current, fileTokens: [...(current.fileTokens ?? []), fileToken] };
+      manifest = {
+        status: 'finalized',
+        files: [
+          {
+            contentType,
+            location: `${this.config.shl.publicBaseUrl}/file/${fileToken.token}`,
+          },
+        ],
+      };
+    }
+
+    await this.store.save(current);
+    return { kind: 'ok', manifest };
+  }
+
+  /**
+   * Resolve a `location` file fetch by its short-lived token.
+   * Tokens embed the SHLink id (`<shlId>~<random>`) so we can look up the link
+   * directly without a custom search parameter.
+   */
+  async getFile(token: string): Promise<FileResult> {
+    const shlinkId = token.split('~')[0];
+    if (!shlinkId) return { kind: 'not-found' };
+
+    const shlink = await this.store.get(shlinkId);
+    if (!shlink || !shlink.encryptedFile) return { kind: 'not-found' };
+
+    const entry = (shlink.fileTokens ?? []).find((t) => t.token === token);
+    if (!entry) return { kind: 'not-found' };
+    if (Date.now() > entry.expiresAtMs || this.isExpired(shlink)) {
+      return { kind: 'gone' };
+    }
+    return { kind: 'ok', jwe: shlink.encryptedFile };
+  }
+
+  // --- internals -----------------------------------------------------------
+
+  private mintFileToken(shlinkId: string): FileToken {
+    return {
+      // <shlId>~<random> — the prefix lets getFile() find the link without a search param.
+      token: `${shlinkId}~${generateShlKey()}`,
+      expiresAtMs: Date.now() + this.config.shlPolicy.fileTokenTtlSeconds * 1000,
+    };
+  }
+
+  private buildPayload(shlink: SHLinkResource): SHLPayload {
+    const payload: SHLPayload = {
+      url: `${this.config.shl.publicBaseUrl}/manifest/${shlink.id}`,
+      key: shlink.key,
+      // L: long-term (contents evolve pending -> ready). P added when a passcode is set.
+      flag: shlink.passcode ? 'LP' : 'L',
+      label: shlink.label,
+      v: 1,
+    };
+    if (shlink.exp !== undefined) payload.exp = shlink.exp;
+    return payload;
+  }
+
+  private buildShlinkUri(shlink: SHLinkResource): string {
+    return encodeShlink(this.buildPayload(shlink), this.config.shl.viewerUrl);
+  }
+
+  private isExpired(shlink: SHLinkResource): boolean {
+    return shlink.exp !== undefined && shlink.exp < Math.floor(Date.now() / 1000);
+  }
+}

--- a/aidbox-integrations/smart-health-link/src/services/shlink-store.ts
+++ b/aidbox-integrations/smart-health-link/src/services/shlink-store.ts
@@ -1,0 +1,23 @@
+import type { FhirClient } from './fhir-client.ts';
+import type { SHLinkResource } from '../types/shlink-resource.ts';
+
+/** Persistence for the SHLink custom resource. */
+export class SHLinkStore {
+  constructor(private readonly fhir: FhirClient) {}
+
+  create(resource: Omit<SHLinkResource, 'resourceType' | 'id'>): Promise<SHLinkResource> {
+    return this.fhir.create<SHLinkResource>('SHLink', {
+      resourceType: 'SHLink',
+      ...resource,
+    });
+  }
+
+  get(id: string): Promise<SHLinkResource | null> {
+    return this.fhir.read<SHLinkResource>('SHLink', id);
+  }
+
+  save(resource: SHLinkResource): Promise<SHLinkResource> {
+    if (!resource.id) throw new Error('Cannot save SHLink without id');
+    return this.fhir.put<SHLinkResource>('SHLink', resource.id, resource);
+  }
+}

--- a/aidbox-integrations/smart-health-link/src/types/config.ts
+++ b/aidbox-integrations/smart-health-link/src/types/config.ts
@@ -1,0 +1,70 @@
+export interface Config {
+  aidbox: {
+    baseUrl: string;
+    clientId: string;
+    clientSecret: string;
+  };
+  shl: {
+    /** Public base URL of this app as reachable by the SHL receiver (used to build manifest/file URLs). */
+    publicBaseUrl: string;
+    /** Optional viewer URL prepended to the shlink: payload. Must end with '#'. Empty for a bare shlink:. */
+    viewerUrl: string;
+  };
+  rte: {
+    /** Simulated real-time eligibility processing delay, in seconds. */
+    processingSeconds: number;
+  };
+  shlPolicy: {
+    /** Lifetime incorrect-passcode attempts allowed before a link locks (P flag). */
+    passcodeMaxAttempts: number;
+    /** Lifetime of a manifest-issued `location` URL, in seconds (spec: ≤ 3600). */
+    fileTokenTtlSeconds: number;
+    /** Minimum seconds between manifest requests for one link before 429. */
+    manifestMinIntervalSeconds: number;
+  };
+  server: {
+    port: number;
+  };
+}
+
+export function loadConfig(): Config {
+  const requiredEnvVars = [
+    'AIDBOX_BASE_URL',
+    'AIDBOX_CLIENT_ID',
+    'AIDBOX_CLIENT_SECRET',
+    'SHL_PUBLIC_BASE_URL',
+  ];
+
+  for (const envVar of requiredEnvVars) {
+    if (!process.env[envVar]) {
+      throw new Error(`Missing required environment variable: ${envVar}`);
+    }
+  }
+
+  return {
+    aidbox: {
+      // The Aidbox client prepends "/fhir" itself — pass the bare host here.
+      baseUrl: process.env.AIDBOX_BASE_URL!.replace(/\/fhir\/?$/, '').replace(/\/$/, ''),
+      clientId: process.env.AIDBOX_CLIENT_ID!,
+      clientSecret: process.env.AIDBOX_CLIENT_SECRET!,
+    },
+    shl: {
+      publicBaseUrl: process.env.SHL_PUBLIC_BASE_URL!.replace(/\/$/, ''),
+      viewerUrl: process.env.SHL_VIEWER_URL || '',
+    },
+    rte: {
+      processingSeconds: parseInt(process.env.RTE_PROCESSING_SECONDS || '10', 10),
+    },
+    shlPolicy: {
+      passcodeMaxAttempts: parseInt(process.env.SHL_PASSCODE_MAX_ATTEMPTS || '5', 10),
+      fileTokenTtlSeconds: parseInt(process.env.SHL_FILE_TOKEN_TTL_SECONDS || '60', 10),
+      manifestMinIntervalSeconds: parseInt(
+        process.env.SHL_MANIFEST_MIN_INTERVAL_SECONDS || '1',
+        10
+      ),
+    },
+    server: {
+      port: parseInt(process.env.PORT || '3000', 10),
+    },
+  };
+}

--- a/aidbox-integrations/smart-health-link/src/types/operation.ts
+++ b/aidbox-integrations/smart-health-link/src/types/operation.ts
@@ -1,0 +1,26 @@
+/**
+ * Shape of the request Aidbox sends to an App endpoint when one of its
+ * configured `operations` is triggered.
+ */
+export interface AidboxOperationRequest {
+  type: string;
+  operation: {
+    id: string;
+  };
+  request: {
+    // For POST operations, the parsed request body (e.g. a FHIR Parameters or the SHL manifest request body).
+    resource?: unknown;
+    // Path placeholders declared in App.operations[].path, e.g. { shlId } or { fileId }.
+    'route-params': Record<string, string>;
+    // Query string params.
+    params?: Record<string, string>;
+    headers: Record<string, string>;
+  };
+}
+
+/** Body of a SMART Health Links manifest request (POST to the manifest URL). */
+export interface ManifestRequestBody {
+  recipient: string;
+  passcode?: string;
+  embeddedLengthMax?: number;
+}

--- a/aidbox-integrations/smart-health-link/src/types/shl.ts
+++ b/aidbox-integrations/smart-health-link/src/types/shl.ts
@@ -1,0 +1,50 @@
+/**
+ * SMART Health Links domain types.
+ * Spec: https://hl7.org/fhir/uv/smart-health-cards-and-links/STU1/links-specification.html
+ */
+
+/** The JSON payload that gets base64url-encoded into a `shlink:` URI. */
+export interface SHLPayload {
+  /** Manifest URL for this SMART Health Link. */
+  url: string;
+  /** 43-char base64url of 32 random bytes — the AES key all files are encrypted under. */
+  key: string;
+  /** Optional expiration time, epoch seconds. */
+  exp?: number;
+  /** Single-char flags concatenated alphabetically: L (long-term), P (passcode), U (direct file). */
+  flag?: string;
+  /** Short (<=80 char) human description of the data. */
+  label?: string;
+  /** Protocol version (defaults to 1). */
+  v?: number;
+}
+
+/** Content types the SHL protocol uses for manifest files. */
+export type SHLFileContentType =
+  | 'application/smart-health-card'
+  | 'application/fhir+json'
+  | 'application/smart-api-access';
+
+/** One entry in the manifest `files` array. */
+export interface ManifestFile {
+  contentType: SHLFileContentType;
+  /** Short-lived, single-use URL to fetch the JWE. Present unless `embedded` is used. */
+  location?: string;
+  /** The JWE compact serialization inlined directly. Present when small enough. */
+  embedded?: string;
+}
+
+/** Manifest response body returned to the SHL receiver. */
+export interface ManifestResponse {
+  /**
+   * Lifecycle status of the manifest contents:
+   * - can-change: contents may still evolve (our RTE job is still running)
+   * - finalized: contents are stable (result is ready)
+   * - no-longer-valid: link is expired/revoked
+   */
+  status: 'can-change' | 'finalized' | 'no-longer-valid';
+  files: ManifestFile[];
+}
+
+/** Status of the simulated real-time eligibility (RTE) job behind an SHL. */
+export type EligibilityJobStatus = 'pending' | 'ready';

--- a/aidbox-integrations/smart-health-link/src/types/shlink-resource.ts
+++ b/aidbox-integrations/smart-health-link/src/types/shlink-resource.ts
@@ -1,0 +1,61 @@
+import type { EligibilityJobStatus } from './shl.ts';
+
+/**
+ * Custom Aidbox resource that persists the state of one SMART Health Link.
+ *
+ * Registered as a first-class resource type via the init bundle. This is the
+ * server-side record behind a `shlink:` — the receiver never sees it directly.
+ *
+ * Security note: we persist `key` so the background worker can encrypt the RTE
+ * result once it's ready (the result lands *after* the link is minted, and the
+ * link is long-term / `L`). The key is the only secret that makes the encrypted
+ * file readable; in production you would keep it out of long-term storage (e.g.
+ * hold it only in the worker, or encrypt-on-write and discard).
+ */
+/** A short-lived, single manifest-issued handle to the encrypted file (the SHL `location` URL). */
+export interface FileToken {
+  /** Random opaque token used in the file URL. */
+  token: string;
+  /** Epoch-ms after which the token is dead (spec: ≤ 1 hour). */
+  expiresAtMs: number;
+}
+
+export interface SHLinkResource {
+  resourceType: 'SHLink';
+  id?: string;
+  /** Content-encryption key (43-char base64url of 32 bytes). */
+  key: string;
+  /** Human label surfaced in the shlink: payload. */
+  label: string;
+  /** Status of the underlying RTE job. */
+  jobStatus: EligibilityJobStatus;
+  /**
+   * What the link carries. SHL is content-agnostic — this is the media type of
+   * the decrypted bytes (e.g. application/fhir+json, application/smart-health-card).
+   */
+  contentType?: string;
+  /**
+   * Optional reference to whatever resource produced the encrypted content
+   * (e.g. CoverageEligibilityResponse/123). Kept generic — the link doesn't
+   * care what kind of resource it points at.
+   */
+  sourceRef?: string;
+  /** The encrypted (JWE) result file, populated when the job finishes. */
+  encryptedFile?: string;
+  /** Epoch-seconds expiration mirrored into the shlink: payload. */
+  exp?: number;
+
+  // --- passcode (P flag) ---
+  /** Passcode required to resolve the manifest, if the P flag is set. */
+  passcode?: string;
+  /** Remaining incorrect-passcode attempts over the link's whole lifetime. */
+  remainingAttempts?: number;
+
+  // --- location file tokens (short-lived `location` URLs) ---
+  /** Active file tokens minted by manifest requests. */
+  fileTokens?: FileToken[];
+
+  // --- manifest poll throttle (429 / Retry-After) ---
+  /** Epoch-ms of the most recent manifest request, for rate-limiting. */
+  lastManifestAtMs?: number;
+}

--- a/aidbox-integrations/smart-health-link/src/utils/crypto.ts
+++ b/aidbox-integrations/smart-health-link/src/utils/crypto.ts
@@ -1,0 +1,40 @@
+import { CompactEncrypt, compactDecrypt, base64url } from 'jose';
+
+/**
+ * Crypto helpers for SMART Health Links.
+ *
+ * Every file shared through an SHL is encrypted with AES-256-GCM using a single
+ * 32-byte key that travels inside the `shlink:` payload. Whoever holds that key
+ * (the client that minted the link) can decrypt; nobody else can — which is
+ * exactly the "only the client that kicked off the job can read it" property
+ * the use case requires. The server stores only ciphertext.
+ */
+
+/** Generate a fresh 32-byte content-encryption key, base64url-encoded (43 chars). */
+export function generateShlKey(): string {
+  const raw = new Uint8Array(32);
+  crypto.getRandomValues(raw);
+  return base64url.encode(raw);
+}
+
+/**
+ * Encrypt a UTF-8 string into a JWE compact serialization using direct (`dir`)
+ * AES-256-GCM encryption. `cty` records the decrypted payload's content type per spec.
+ */
+export async function encryptToJwe(
+  plaintext: string,
+  keyB64url: string,
+  contentType: string
+): Promise<string> {
+  const key = base64url.decode(keyB64url);
+  return new CompactEncrypt(new TextEncoder().encode(plaintext))
+    .setProtectedHeader({ alg: 'dir', enc: 'A256GCM', cty: contentType })
+    .encrypt(key);
+}
+
+/** Decrypt a JWE compact serialization back to its UTF-8 plaintext. */
+export async function decryptJwe(jwe: string, keyB64url: string): Promise<string> {
+  const key = base64url.decode(keyB64url);
+  const { plaintext } = await compactDecrypt(jwe, key);
+  return new TextDecoder().decode(plaintext);
+}

--- a/aidbox-integrations/smart-health-link/src/utils/shl-encode.ts
+++ b/aidbox-integrations/smart-health-link/src/utils/shl-encode.ts
@@ -1,0 +1,30 @@
+import { base64url } from 'jose';
+import type { SHLPayload } from '../types/shl.ts';
+
+/**
+ * Encode an SHL payload into a `shlink:` URI.
+ *
+ *   1. minify the JSON payload
+ *   2. base64url-encode it
+ *   3. prefix with `shlink:/`
+ *   4. optionally prepend a viewer URL ending in `#`
+ *
+ * e.g. https://viewer.example.org#shlink:/eyJ1cmwiOiI...
+ */
+export function encodeShlink(payload: SHLPayload, viewerUrl = ''): string {
+  const json = JSON.stringify(payload);
+  const encoded = base64url.encode(new TextEncoder().encode(json));
+  return `${viewerUrl}shlink:/${encoded}`;
+}
+
+/** Decode a `shlink:` URI (with or without a viewer prefix) back to its payload. */
+export function decodeShlink(shlink: string): SHLPayload {
+  const marker = 'shlink:/';
+  const idx = shlink.indexOf(marker);
+  if (idx === -1) {
+    throw new Error('Not a shlink: URI');
+  }
+  const encoded = shlink.slice(idx + marker.length);
+  const json = new TextDecoder().decode(base64url.decode(encoded));
+  return JSON.parse(json) as SHLPayload;
+}

--- a/aidbox-integrations/smart-health-link/src/viewer.html
+++ b/aidbox-integrations/smart-health-link/src/viewer.html
@@ -12,7 +12,8 @@
     --line: #2B3A5E;
     --text: #E6EAF2;
     --muted: #93A1C0;
-    --accent: #5EEAD4;   /* unlocked / verified */
+    --accent: #5EEAD4;   /* unlocked / verified / runs in the browser */
+    --server: #b794f4;   /* runs on the server (Aidbox + backend) */
     --locked: #F4A259;   /* locked / pending */
     --danger: #F47174;
     --mono: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
@@ -198,10 +199,15 @@
   .qrbox .qr-caption b { color: var(--text); font-weight: 600; }
 
   /* ---- stepper ---- */
-  .steps-hint {
-    margin: 28px 0 8px; font-size: 12px; color: var(--muted); font-family: var(--mono);
-    letter-spacing: .04em;
+  .bts-toggle {
+    margin: 32px 0 12px; padding: 0; background: none; border: none; cursor: pointer;
+    display: flex; align-items: center; gap: 8px;
+    font-family: var(--display); font-weight: 600; font-size: 18px; color: var(--text);
+    letter-spacing: -0.01em;
   }
+  .bts-chev { color: var(--muted); transition: transform .15s; }
+  .bts-toggle[aria-expanded="true"] .bts-chev { transform: rotate(90deg); }
+  .bts.collapsed { display: none; }
   .steps { margin: 0; padding: 0; list-style: none; display: grid; gap: 2px; }
   .step { background: var(--panel); border: 1px solid var(--line); }
   .step:first-child { border-radius: 12px 12px 0 0; }
@@ -210,7 +216,7 @@
   .step-head {
     width: 100%;
     display: grid;
-    grid-template-columns: 40px 1fr auto auto;
+    grid-template-columns: 40px 1fr auto auto auto;
     align-items: center;
     gap: 14px;
     padding: 14px 16px;
@@ -254,6 +260,14 @@
   .step[data-state="active"] .state { color: var(--locked); }
   .step[data-state="done"] .num { border-color: var(--accent); color: var(--accent); }
   .step[data-state="done"] .state { color: var(--accent); }
+
+  /* where each step runs */
+  .where {
+    font-family: var(--mono); font-size: 10px; letter-spacing: .08em; text-transform: uppercase;
+    padding: 2px 8px; border-radius: 999px; border: 1px solid var(--line); white-space: nowrap;
+  }
+  .where.browser { color: var(--accent); border-color: var(--accent); }
+  .where.server  { color: var(--server); border-color: var(--server); }
   .step[data-state="error"] { border-color: var(--danger); }
   .step[data-state="error"] .num,
   .step[data-state="error"] .state { color: var(--danger); border-color: var(--danger); }
@@ -271,6 +285,7 @@
   }
   .api pre {
     margin: 0; max-height: 220px; padding: 12px 14px; font-size: 12px; border-radius: 8px;
+    white-space: pre-wrap; word-break: break-all; overflow-x: hidden;
   }
   .api .req .verb { color: var(--accent); }
   .api .note { font-size: 12.5px; color: var(--muted); line-height: 1.5; }
@@ -344,8 +359,8 @@
   <div class="wrap">
     <header>
       <p class="eyebrow">SMART Health Link · End-to-end demo</p>
-      <h1>Check eligibility, then unlock the result</h1>
-      <p class="sub">Start an eligibility check the way a prospective member would — before signing up. You get back a <code>shlink:</code> whose key only you hold. The result is produced asynchronously, fetched encrypted, and decrypted right here in your browser. Nothing readable ever touches the server.</p>
+      <h1>Check your coverage before signing up</h1>
+      <p class="sub">Fill in your details and start a check. You get back a private link, and this page fetches the result and unlocks it right in your browser. The server never sees the readable answer.</p>
     </header>
 
     <div class="card">
@@ -374,13 +389,12 @@
             <input id="recipient" type="text" value="SHL Viewer (demo)" spellcheck="false" />
           </div>
           <div class="span2">
-            <label class="fld" for="passcode">Passcode <span class="opt">— optional, adds the P flag</span></label>
+            <label class="fld" for="passcode">Passcode <span class="opt">(optional, adds the P flag)</span></label>
             <input id="passcode" type="text" value="" placeholder="leave empty for an L-only link" spellcheck="false" />
           </div>
         </div>
         <div class="row">
           <button id="start">Start check</button>
-          <span class="recipient-note">runs <code>$kickoff</code>, then polls until ready</span>
         </div>
       </div>
 
@@ -390,7 +404,7 @@
         <textarea id="shl" placeholder="shlink:/eyJ1cmwiOiJodHRw…  (or a viewer URL containing one)" spellcheck="false"></textarea>
         <div class="grid2" style="margin-top:14px">
           <div>
-            <label class="fld" for="passcode-open">Passcode <span class="opt">— if the link has the P flag</span></label>
+            <label class="fld" for="passcode-open">Passcode <span class="opt">(if the link has the P flag)</span></label>
             <input id="passcode-open" type="text" value="" placeholder="only if required" spellcheck="false" />
           </div>
           <div>
@@ -405,6 +419,20 @@
       </div>
     </div>
 
+    <!-- Decrypted result / encrypted payload, shown first, above the details -->
+    <div class="reveal hidden" id="reveal">
+      <div class="reveal-head">
+        <h2 id="reveal-title">Encrypted payload</h2>
+        <span class="badge locked" id="badge">locked</span>
+      </div>
+      <ul class="meta hidden" id="meta"></ul>
+      <pre id="out" class="cipher"></pre>
+    </div>
+
+    <!-- Behind the scenes: the minted link, its QR, and the HTTP steps -->
+    <button class="bts-toggle" id="bts-toggle" type="button" aria-expanded="true">Behind the scenes <span class="bts-chev" aria-hidden="true">›</span></button>
+    <div class="bts" id="bts">
+
     <!-- Minted link, shown after kickoff -->
     <div class="linkbox hidden" id="linkbox">
       <span class="linkbox-label">Your SMART Health Link</span>
@@ -415,66 +443,62 @@
     <!-- QR encoding of the link, shown after kickoff -->
     <div class="qrbox hidden" id="qrbox">
       <canvas id="qr" width="140" height="140" aria-label="QR code for the SMART Health Link"></canvas>
-      <p class="qr-caption">Scan with a <b>SMART Health Links</b> wallet to open the result on a phone. The QR encodes the same <code>shlink:</code> above — the decryption key travels in it, so treat it like a secret.</p>
+      <p class="qr-caption">Scan with a <b>SMART Health Links</b> wallet to open it on a phone. The QR holds the same <code>shlink:</code>, key included, so treat it as a secret.</p>
     </div>
 
-    <p class="steps-hint">Click any step to see the HTTP call behind it.</p>
     <ol class="steps" id="steps">
-      <li class="step" data-step="kickoff">
+      <li class="step" data-step="kickoff" data-where="server">
         <button class="step-head" aria-expanded="false" aria-controls="api-kickoff">
-          <span class="num">00</span>
+          <span class="num">01</span>
           <span class="step-body"><span class="name">Start the check</span><span class="detail" id="d-kickoff">mint a shlink: and begin the eligibility job</span></span>
+          <span class="where server">server</span>
           <span class="state" id="s-kickoff">idle</span>
           <span class="chev" aria-hidden="true">›</span>
         </button>
         <div class="api hidden" id="api-kickoff"></div>
       </li>
-      <li class="step" data-step="decode">
+      <li class="step" data-step="decode" data-where="browser">
         <button class="step-head" aria-expanded="false" aria-controls="api-decode">
-          <span class="num">01</span>
-          <span class="step-body"><span class="name">Decode the link</span><span class="detail" id="d-decode">read url + key from the shlink payload</span></span>
+          <span class="num">02</span>
+          <span class="step-body"><span class="name">Read the link</span><span class="detail" id="d-decode">decode url + key from the shlink: payload</span></span>
+          <span class="where browser">browser</span>
           <span class="state" id="s-decode">idle</span>
           <span class="chev" aria-hidden="true">›</span>
         </button>
         <div class="api hidden" id="api-decode"></div>
       </li>
-      <li class="step" data-step="manifest">
+      <li class="step" data-step="manifest" data-where="server">
         <button class="step-head" aria-expanded="false" aria-controls="api-manifest">
-          <span class="num">02</span>
-          <span class="step-body"><span class="name">Poll the manifest</span><span class="detail" id="d-manifest">can-change while the job runs, then finalized</span></span>
+          <span class="num">03</span>
+          <span class="step-body"><span class="name">Wait for the eligibility result</span><span class="detail" id="d-manifest">the server is checking your coverage with the payer; poll until it's ready</span></span>
+          <span class="where server">server</span>
           <span class="state" id="s-manifest">idle</span>
           <span class="chev" aria-hidden="true">›</span>
         </button>
         <div class="api hidden" id="api-manifest"></div>
       </li>
-      <li class="step" data-step="fetch">
+      <li class="step" data-step="fetch" data-where="server">
         <button class="step-head" aria-expanded="false" aria-controls="api-fetch">
-          <span class="num">03</span>
-          <span class="step-body"><span class="name">Get the encrypted file</span><span class="detail" id="d-fetch">embedded JWE, or fetch the location URL</span></span>
+          <span class="num">04</span>
+          <span class="step-body"><span class="name">Download the result</span><span class="detail" id="d-fetch">encrypted (JWE), embedded or via a location URL</span></span>
+          <span class="where server">server</span>
           <span class="state" id="s-fetch">idle</span>
           <span class="chev" aria-hidden="true">›</span>
         </button>
         <div class="api hidden" id="api-fetch"></div>
       </li>
-      <li class="step" data-step="decrypt">
+      <li class="step" data-step="decrypt" data-where="browser">
         <button class="step-head" aria-expanded="false" aria-controls="api-decrypt">
-          <span class="num">04</span>
-          <span class="step-body"><span class="name">Decrypt with your key</span><span class="detail" id="d-decrypt">AES-256-GCM, client-side</span></span>
+          <span class="num">05</span>
+          <span class="step-body"><span class="name">Decrypt with your key</span><span class="detail" id="d-decrypt">decrypt locally (AES-256-GCM), no network</span></span>
+          <span class="where browser">browser</span>
           <span class="state" id="s-decrypt">idle</span>
           <span class="chev" aria-hidden="true">›</span>
         </button>
         <div class="api hidden" id="api-decrypt"></div>
       </li>
     </ol>
-
-    <div class="reveal hidden" id="reveal">
-      <div class="reveal-head">
-        <h2 id="reveal-title">Encrypted payload</h2>
-        <span class="badge locked" id="badge">locked</span>
-      </div>
-      <ul class="meta hidden" id="meta"></ul>
-      <pre id="out" class="cipher"></pre>
-    </div>
+    </div><!-- /bts -->
 
     <div class="err hidden" id="error"></div>
 
@@ -617,7 +641,7 @@
         m[6][i] = i % 2 === 0 ? 1 : 0; reserved[6][i] = 1;
         m[i][6] = i % 2 === 0 ? 1 : 0; reserved[i][6] = 1;
       }
-      // alignment patterns — omit the three that would collide with a finder
+      // alignment patterns: omit the three that would collide with a finder
       // (centers near the top-left, top-right, and bottom-left finder cores).
       const centers = ALIGN[v] || [];
       const last = centers.length - 1;
@@ -704,14 +728,14 @@
       for (let i = 0; i < 10; i++) rem = (rem << 1) ^ ((rem >> 9) & 1 ? 0x537 : 0);
       const bits = (((data << 10) | rem) ^ 0x5412);
       const get = (i) => (bits >> i) & 1;
-      // Copy 1 — wraps the top-left finder (skipping the timing row/col at 6).
+      // Copy 1: wraps the top-left finder (skipping the timing row/col at 6).
       const tl = [
         [8, 0, 14], [8, 1, 13], [8, 2, 12], [8, 3, 11], [8, 4, 10], [8, 5, 9],
         [8, 7, 8], [8, 8, 7], [7, 8, 6], [5, 8, 5], [4, 8, 4], [3, 8, 3],
         [2, 8, 2], [1, 8, 1], [0, 8, 0],
       ];
       for (const [r, c, i] of tl) m[r][c] = get(i);
-      // Copy 2 — bottom-left strip holds the high bits, top-right strip the low bits.
+      // Copy 2: bottom-left strip holds the high bits, top-right strip the low bits.
       for (let i = 0; i < 7; i++) m[n - 1 - i][8] = get(8 + i);     // rows n-1..n-7  ← bits 8..14
       for (let i = 0; i < 8; i++) m[8][n - 1 - i] = get(i);          // cols n-1..n-8  ← bits 0..7
     }
@@ -861,10 +885,10 @@ authorization: Basic <client:secret>
 }`,
     };
     apiLog.decode = {
-      note: 'No network call — the <code>shlink:</code> is base64url-decoded in the browser to read its <code>url</code> and <code>key</code>.',
+      note: 'No network call. The browser base64url-decodes the <code>shlink:</code> to read its <code>url</code> and <code>key</code>.',
     };
     apiLog.manifest = {
-      note: 'Public. Polled until <code>status: finalized</code>. If the link has the <code>P</code> flag, the body also carries <code>passcode</code> — a wrong one returns <code>401 { remainingAttempts }</code>, and too-frequent polls return <code>429</code> with <code>Retry-After</code>.',
+      note: 'Public. Polled until <code>status: finalized</code>. If the link has the <code>P</code> flag, the body also carries <code>passcode</code>; a wrong one returns <code>401 { remainingAttempts }</code>, and too-frequent polls return <code>429</code> with <code>Retry-After</code>.',
       request:
 `<span class="verb">POST</span> {shlink.url}
 content-type: application/json
@@ -876,7 +900,7 @@ content-type: application/json
       request: `<span class="verb">GET</span> {file.location}`,
     };
     apiLog.decrypt = {
-      note: 'No network call — AES-256-GCM (JWE <code>alg=dir</code>) decryption happens in the browser with the key from the link.',
+      note: 'No network call. The browser runs AES-256-GCM (JWE <code>alg=dir</code>) decryption with the key from the link.',
     };
     for (const s of STEPS) renderApi(s);
   }
@@ -906,7 +930,7 @@ content-type: application/json
   function decodeShlink(input) {
     const marker = "shlink:/";
     const idx = input.indexOf(marker);
-    if (idx === -1) throw new Error("That doesn't look like a shlink: — no <code>shlink:/</code> marker found.");
+    if (idx === -1) throw new Error("That doesn't look like a shlink:. No <code>shlink:/</code> marker found.");
     const encoded = input.slice(idx + marker.length).trim();
     const json = new TextDecoder().decode(b64urlToBytes(encoded));
     return JSON.parse(json);
@@ -1005,16 +1029,16 @@ content-type: application/json
       payload = decodeShlink(raw);
       if (!payload.url || !payload.key) throw new Error("Link is missing <code>url</code> or <code>key</code>.");
       const needsPasscode = (payload.flag || "").includes("P");
-      setStep("decode", "done", `key ${payload.key.slice(0, 6)}… · flag ${payload.flag || "—"}`);
+      setStep("decode", "done", `key ${payload.key.slice(0, 6)}… · flag ${payload.flag || "none"}`);
       setApi("decode", {
         note: needsPasscode
-          ? "Flag includes <code>P</code> — the manifest request must carry a passcode."
+          ? "Flag includes <code>P</code>, so the manifest request must carry a passcode."
           : undefined,
         response: JSON.stringify({ ...payload, key: payload.key.slice(0, 8) + "…(redacted)" }, null, 2),
         status: "decoded locally",
       });
       if (needsPasscode && !passcode) {
-        fail("manifest", "This link has the <code>P</code> flag — enter the passcode and try again.");
+        fail("manifest", "This link has the <code>P</code> flag. Enter the passcode and try again.");
         return;
       }
     } catch (e) { fail("decode", e.message); return; }
@@ -1039,7 +1063,7 @@ ${JSON.stringify(reqBodyShown, null, 2)}`;
           body: JSON.stringify(reqBody),
         });
 
-        // 429: server is throttling polls — honor Retry-After.
+        // 429: server is throttling polls, honor Retry-After.
         if (res.status === 429) {
           const ra = parseInt(res.headers.get("retry-after") || "1", 10) || 1;
           setApi("manifest", {
@@ -1074,7 +1098,7 @@ ${JSON.stringify(reqBodyShown, null, 2)}`;
         manifest = await res.json();
         polls++;
         setApi("manifest", {
-          note: `Public${passcode ? ", passcode-gated" : ", unauthenticated"}. Poll ${polls}${manifest.status === "finalized" ? " — finalized." : " — still " + esc(manifest.status) + ", will retry."}`,
+          note: `Public${passcode ? ", passcode-gated" : ", unauthenticated"}. Poll ${polls}${manifest.status === "finalized" ? ", finalized." : ", still " + esc(manifest.status) + ", will retry."}`,
           request: manifestReq,
           response: JSON.stringify(redactManifest(manifest), null, 2),
           status: `HTTP ${res.status} · ${manifest.status}`,
@@ -1090,9 +1114,9 @@ ${JSON.stringify(reqBodyShown, null, 2)}`;
           throw new Error("This link is no longer valid.");
         }
         if (Date.now() > deadline) {
-          throw new Error(`Still ${manifest.status} after ${Math.round(POLL_TIMEOUT_MS / 1000)}s — giving up.`);
+          throw new Error(`Still ${manifest.status} after ${Math.round(POLL_TIMEOUT_MS / 1000)}s, giving up.`);
         }
-        // can-change: job still running — keep polling.
+        // can-change: job still running, keep polling.
         setStep("manifest", "active", `can-change · polling (${polls})…`);
         await sleep(POLL_INTERVAL_MS);
       }
@@ -1107,7 +1131,7 @@ ${JSON.stringify(reqBodyShown, null, 2)}`;
         jwe = file.embedded;
         setStep("fetch", "done", "used embedded JWE");
         setApi("fetch", {
-          note: "The manifest inlined the file as <code>embedded</code> — no extra request needed.",
+          note: "The manifest inlined the file as <code>embedded</code>, so no extra request is needed.",
           request: undefined,
           response: jwe.slice(0, 120) + "…  (JWE compact serialization, application/jose)",
           status: "embedded in manifest",
@@ -1142,12 +1166,12 @@ ${JSON.stringify(reqBodyShown, null, 2)}`;
       const text = await decryptJwe(jwe, payload.key);
       setStep("decrypt", "done", "decrypted in-browser");
       setApi("decrypt", {
-        response: "Decrypted in-browser with WebCrypto (AES-256-GCM). The plaintext FHIR resource is shown below — it never traveled over the network.",
+        response: "Decrypted in-browser with WebCrypto (AES-256-GCM). The plaintext FHIR resource appears below. It never traveled over the network.",
         status: "decrypted locally",
       });
       showResult(text, payload);
     } catch (e) {
-      fail("decrypt", `Couldn't decrypt — the key may not match this file. <code>${e.message}</code>`);
+      fail("decrypt", `Couldn't decrypt; the key may not match this file. <code>${e.message}</code>`);
     }
   }
 
@@ -1214,7 +1238,7 @@ ${JSON.stringify(kickoffParams, null, 2)}`,
       $("shlink-out").textContent = shlink;
       $("linkbox").classList.remove("hidden");
       showQr(shlink);
-    } catch (e) { fail("kickoff", `Couldn't start the check — <code>${e.message}</code>`); setBusy(false); return; }
+    } catch (e) { fail("kickoff", `Couldn't start the check. <code>${e.message}</code>`); setBusy(false); return; }
 
     await resolveAndDecrypt(shlink, recipient, passcode);
     setBusy(false);
@@ -1224,7 +1248,7 @@ ${JSON.stringify(kickoffParams, null, 2)}`,
   async function openLink() {
     if (running) return;
     resetSteps();
-    setStep("kickoff", "done", "n/a — opened an existing link");
+    setStep("kickoff", "done", "n/a, opened an existing link");
     const raw = $("shl").value.trim();
     if (!raw) { fail("decode", "Paste a <code>shlink:</code> first."); return; }
     setBusy(true);
@@ -1241,9 +1265,17 @@ ${JSON.stringify(kickoffParams, null, 2)}`,
     $("tab-open").setAttribute("aria-selected", String(!start));
     $("pane-start").classList.toggle("hidden", !start);
     $("pane-open").classList.toggle("hidden", start);
+    // Step 00 (kickoff) only applies when you start a check; hide it when opening an existing link.
+    document.querySelector('.step[data-step="kickoff"]').classList.toggle("hidden", !start);
   }
   $("tab-start").addEventListener("click", () => selectTab("start"));
   $("tab-open").addEventListener("click", () => selectTab("open"));
+  $("bts-toggle").addEventListener("click", () => {
+    const b = $("bts-toggle");
+    const open = b.getAttribute("aria-expanded") === "true";
+    b.setAttribute("aria-expanded", String(!open));
+    $("bts").classList.toggle("collapsed", open);
+  });
 
   $("start").addEventListener("click", startCheck);
   $("open").addEventListener("click", openLink);
@@ -1254,7 +1286,7 @@ ${JSON.stringify(kickoffParams, null, 2)}`,
       QR.draw($("qr"), shlink);
       $("qrbox").classList.remove("hidden");
     } catch (e) {
-      // Link too long to encode — keep the textual link, skip the QR.
+      // Link too long to encode: keep the textual link, skip the QR.
       $("qrbox").classList.add("hidden");
     }
   }

--- a/aidbox-integrations/smart-health-link/src/viewer.html
+++ b/aidbox-integrations/smart-health-link/src/viewer.html
@@ -1,0 +1,1277 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>SMART Health Link Viewer</title>
+<style>
+  :root {
+    --ground: #0F1729;
+    --panel: #16203A;
+    --panel-2: #1E2B4A;
+    --line: #2B3A5E;
+    --text: #E6EAF2;
+    --muted: #93A1C0;
+    --accent: #5EEAD4;   /* unlocked / verified */
+    --locked: #F4A259;   /* locked / pending */
+    --danger: #F47174;
+    --mono: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+    --sans: "Inter", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    --display: "Space Grotesk", var(--sans);
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background:
+      radial-gradient(1200px 600px at 70% -10%, #1b2747 0%, transparent 60%),
+      var(--ground);
+    color: var(--text);
+    font-family: var(--sans);
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 48px 24px 96px;
+  }
+
+  /* ---- header ---- */
+  header { margin-bottom: 36px; }
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: 12px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0 0 12px;
+  }
+  h1 {
+    font-family: var(--display);
+    font-weight: 600;
+    font-size: clamp(28px, 5vw, 40px);
+    letter-spacing: -0.02em;
+    margin: 0 0 8px;
+  }
+  .sub { color: var(--muted); margin: 0; max-width: 56ch; }
+
+  /* ---- input card ---- */
+  .card {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    padding: 20px;
+  }
+  label.fld {
+    display: block;
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: 8px;
+  }
+  textarea {
+    width: 100%;
+    min-height: 84px;
+    resize: vertical;
+    background: var(--ground);
+    color: var(--text);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 12px 14px;
+    font-family: var(--mono);
+    font-size: 13px;
+    line-height: 1.5;
+    word-break: break-all;
+  }
+  textarea:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+  .row { display: flex; gap: 12px; align-items: center; margin-top: 14px; flex-wrap: wrap; }
+  button {
+    font-family: var(--sans);
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--ground);
+    background: var(--accent);
+    border: 0;
+    border-radius: 10px;
+    padding: 11px 20px;
+    cursor: pointer;
+    transition: transform .08s ease, filter .15s ease;
+  }
+  button:hover { filter: brightness(1.08); }
+  button:active { transform: translateY(1px); }
+  button:disabled { opacity: .5; cursor: not-allowed; }
+  button:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
+  button.ghost {
+    background: transparent;
+    color: var(--muted);
+    border: 1px solid var(--line);
+  }
+  button.small { padding: 7px 14px; font-size: 13px; }
+  .recipient-note {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--muted);
+    margin-left: auto;
+  }
+  .recipient-note #recipient-open { color: var(--text); }
+
+  /* ---- tabs ---- */
+  .tabs { display: flex; gap: 4px; margin-bottom: 18px; }
+  .tab {
+    background: transparent;
+    color: var(--muted);
+    border: 1px solid var(--line);
+    border-radius: 9px;
+    padding: 8px 16px;
+    font-size: 13px;
+    font-weight: 500;
+  }
+  .tab[aria-selected="true"] {
+    color: var(--ground);
+    background: var(--accent);
+    border-color: var(--accent);
+  }
+
+  /* ---- form inputs ---- */
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+  .grid2 .span2 { grid-column: 1 / -1; }
+  @media (max-width: 520px) { .grid2 { grid-template-columns: 1fr; } }
+  .opt { color: var(--muted); font-weight: 400; text-transform: none; letter-spacing: 0; }
+  input[type="text"] {
+    width: 100%;
+    background: var(--ground);
+    color: var(--text);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 10px 13px;
+    font-family: var(--sans);
+    font-size: 14px;
+  }
+  input[type="text"]:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+  /* ---- minted link box ---- */
+  .linkbox {
+    display: flex; align-items: center; gap: 12px;
+    margin-top: 16px;
+    background: var(--panel-2);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 12px 14px;
+  }
+  .linkbox-label {
+    font-family: var(--mono); font-size: 11px; letter-spacing: .12em; text-transform: uppercase;
+    color: var(--muted); white-space: nowrap;
+  }
+  .linkbox code {
+    flex: 1; min-width: 0;
+    font-family: var(--mono); font-size: 12px; color: var(--accent);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+
+  /* ---- QR code ---- */
+  .qrbox {
+    margin-top: 12px;
+    display: flex; align-items: center; gap: 16px;
+    background: var(--panel-2);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 14px 16px;
+  }
+  .qrbox canvas {
+    width: 140px; height: 140px;
+    image-rendering: pixelated;
+    background: #fff;
+    border-radius: 8px;
+    padding: 8px;
+    flex: none;
+  }
+  .qrbox .qr-caption {
+    font-size: 13px; color: var(--muted); line-height: 1.5;
+  }
+  .qrbox .qr-caption b { color: var(--text); font-weight: 600; }
+
+  /* ---- stepper ---- */
+  .steps-hint {
+    margin: 28px 0 8px; font-size: 12px; color: var(--muted); font-family: var(--mono);
+    letter-spacing: .04em;
+  }
+  .steps { margin: 0; padding: 0; list-style: none; display: grid; gap: 2px; }
+  .step { background: var(--panel); border: 1px solid var(--line); }
+  .step:first-child { border-radius: 12px 12px 0 0; }
+  .step:last-child { border-radius: 0 0 12px 12px; }
+
+  .step-head {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 40px 1fr auto auto;
+    align-items: center;
+    gap: 14px;
+    padding: 14px 16px;
+    background: none;
+    border: 0;
+    border-radius: inherit;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+  .step-head:hover { background: var(--panel-2); }
+  .step-head:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+  .num {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--muted);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    height: 28px; width: 28px;
+    display: grid; place-items: center;
+  }
+  .step-body { min-width: 0; }
+  .name { font-weight: 500; display: block; }
+  .detail { font-size: 13px; color: var(--muted); margin-top: 3px; font-family: var(--mono); display: block; }
+  .state {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  .chev {
+    font-family: var(--mono); color: var(--muted); font-size: 18px; line-height: 1;
+    transition: transform .15s ease;
+  }
+  .step-head[aria-expanded="true"] .chev { transform: rotate(90deg); }
+
+  .step[data-state="active"] { border-color: var(--locked); }
+  .step[data-state="active"] .num { border-color: var(--locked); color: var(--locked); }
+  .step[data-state="active"] .state { color: var(--locked); }
+  .step[data-state="done"] .num { border-color: var(--accent); color: var(--accent); }
+  .step[data-state="done"] .state { color: var(--accent); }
+  .step[data-state="error"] { border-color: var(--danger); }
+  .step[data-state="error"] .num,
+  .step[data-state="error"] .state { color: var(--danger); border-color: var(--danger); }
+
+  /* ---- per-step API panel ---- */
+  .api {
+    border-top: 1px solid var(--line);
+    padding: 14px 16px 16px;
+    display: grid;
+    gap: 12px;
+  }
+  .api-block .api-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing: .14em; text-transform: uppercase;
+    color: var(--muted); margin: 0 0 6px;
+  }
+  .api pre {
+    margin: 0; max-height: 220px; padding: 12px 14px; font-size: 12px; border-radius: 8px;
+  }
+  .api .req .verb { color: var(--accent); }
+  .api .note { font-size: 12.5px; color: var(--muted); line-height: 1.5; }
+  .api .note code { font-family: var(--mono); color: var(--text); }
+  .status-ok { color: var(--accent); }
+  .status-bad { color: var(--danger); }
+  .status-wait { color: var(--locked); }
+
+  /* ---- reveal ---- */
+  .reveal { margin-top: 28px; }
+  .reveal-head {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 10px;
+  }
+  .reveal-head h2 {
+    font-family: var(--display); font-weight: 600; font-size: 18px; margin: 0;
+    letter-spacing: -0.01em;
+  }
+  .badge {
+    font-family: var(--mono); font-size: 11px; letter-spacing: .1em; text-transform: uppercase;
+    padding: 4px 10px; border-radius: 999px; border: 1px solid var(--line); color: var(--muted);
+  }
+  .badge.locked { color: var(--locked); border-color: var(--locked); }
+  .badge.unlocked { color: var(--accent); border-color: var(--accent); }
+
+  pre {
+    margin: 0;
+    background: var(--ground);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 18px;
+    font-family: var(--mono);
+    font-size: 12.5px;
+    line-height: 1.6;
+    overflow-x: auto;
+    max-height: 460px;
+    overflow-y: auto;
+  }
+  pre.cipher { color: #6E7DA3; word-break: break-all; white-space: pre-wrap; }
+  /* JSON syntax tint */
+  .k { color: var(--accent); }
+  .s { color: #C3E88D; }
+  .n { color: var(--locked); }
+  .b { color: #82AAFF; }
+
+  .meta { display: flex; gap: 18px; flex-wrap: wrap; margin: 0 0 16px; padding: 0; list-style: none; }
+  .meta li { font-size: 13px; color: var(--muted); }
+  .meta b { color: var(--text); font-weight: 600; }
+
+  .err {
+    margin-top: 14px;
+    border: 1px solid var(--danger);
+    background: rgba(244,113,116,.08);
+    color: var(--text);
+    border-radius: 10px;
+    padding: 12px 14px;
+    font-size: 14px;
+  }
+  .err code { font-family: var(--mono); font-size: 12px; color: var(--danger); }
+
+  .hidden { display: none !important; }
+  footer { margin-top: 48px; color: var(--muted); font-size: 12px; font-family: var(--mono); }
+  a { color: var(--accent); }
+
+  @media (prefers-reduced-motion: reduce) {
+    * { transition: none !important; }
+  }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <p class="eyebrow">SMART Health Link · End-to-end demo</p>
+      <h1>Check eligibility, then unlock the result</h1>
+      <p class="sub">Start an eligibility check the way a prospective member would — before signing up. You get back a <code>shlink:</code> whose key only you hold. The result is produced asynchronously, fetched encrypted, and decrypted right here in your browser. Nothing readable ever touches the server.</p>
+    </header>
+
+    <div class="card">
+      <div class="tabs" role="tablist">
+        <button class="tab" id="tab-start" role="tab" aria-selected="true">Start a check</button>
+        <button class="tab" id="tab-open" role="tab" aria-selected="false">Open a link</button>
+      </div>
+
+      <!-- Mode: start a check -->
+      <div class="pane" id="pane-start">
+        <div class="grid2">
+          <div>
+            <label class="fld" for="memberName">Member name</label>
+            <input id="memberName" type="text" value="Jane Prospect" spellcheck="false" />
+          </div>
+          <div>
+            <label class="fld" for="payerName">Payer</label>
+            <input id="payerName" type="text" value="Acme Health" spellcheck="false" />
+          </div>
+          <div>
+            <label class="fld" for="memberId">Member ID</label>
+            <input id="memberId" type="text" value="M-99887" spellcheck="false" />
+          </div>
+          <div>
+            <label class="fld" for="recipient">Recipient (you)</label>
+            <input id="recipient" type="text" value="SHL Viewer (demo)" spellcheck="false" />
+          </div>
+          <div class="span2">
+            <label class="fld" for="passcode">Passcode <span class="opt">— optional, adds the P flag</span></label>
+            <input id="passcode" type="text" value="" placeholder="leave empty for an L-only link" spellcheck="false" />
+          </div>
+        </div>
+        <div class="row">
+          <button id="start">Start check</button>
+          <span class="recipient-note">runs <code>$kickoff</code>, then polls until ready</span>
+        </div>
+      </div>
+
+      <!-- Mode: open an existing link -->
+      <div class="pane hidden" id="pane-open">
+        <label class="fld" for="shl">SMART Health Link</label>
+        <textarea id="shl" placeholder="shlink:/eyJ1cmwiOiJodHRw…  (or a viewer URL containing one)" spellcheck="false"></textarea>
+        <div class="grid2" style="margin-top:14px">
+          <div>
+            <label class="fld" for="passcode-open">Passcode <span class="opt">— if the link has the P flag</span></label>
+            <input id="passcode-open" type="text" value="" placeholder="only if required" spellcheck="false" />
+          </div>
+          <div>
+            <label class="fld" for="recipient-open-input">Recipient (you)</label>
+            <input id="recipient-open-input" type="text" value="SHL Viewer (demo)" spellcheck="false" />
+          </div>
+        </div>
+        <div class="row">
+          <button id="open">Resolve &amp; decrypt</button>
+          <button id="clear" class="ghost" type="button">Clear</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Minted link, shown after kickoff -->
+    <div class="linkbox hidden" id="linkbox">
+      <span class="linkbox-label">Your SMART Health Link</span>
+      <code id="shlink-out"></code>
+      <button class="ghost small" id="copy" type="button">Copy</button>
+    </div>
+
+    <!-- QR encoding of the link, shown after kickoff -->
+    <div class="qrbox hidden" id="qrbox">
+      <canvas id="qr" width="140" height="140" aria-label="QR code for the SMART Health Link"></canvas>
+      <p class="qr-caption">Scan with a <b>SMART Health Links</b> wallet to open the result on a phone. The QR encodes the same <code>shlink:</code> above — the decryption key travels in it, so treat it like a secret.</p>
+    </div>
+
+    <p class="steps-hint">Click any step to see the HTTP call behind it.</p>
+    <ol class="steps" id="steps">
+      <li class="step" data-step="kickoff">
+        <button class="step-head" aria-expanded="false" aria-controls="api-kickoff">
+          <span class="num">00</span>
+          <span class="step-body"><span class="name">Start the check</span><span class="detail" id="d-kickoff">mint a shlink: and begin the eligibility job</span></span>
+          <span class="state" id="s-kickoff">idle</span>
+          <span class="chev" aria-hidden="true">›</span>
+        </button>
+        <div class="api hidden" id="api-kickoff"></div>
+      </li>
+      <li class="step" data-step="decode">
+        <button class="step-head" aria-expanded="false" aria-controls="api-decode">
+          <span class="num">01</span>
+          <span class="step-body"><span class="name">Decode the link</span><span class="detail" id="d-decode">read url + key from the shlink payload</span></span>
+          <span class="state" id="s-decode">idle</span>
+          <span class="chev" aria-hidden="true">›</span>
+        </button>
+        <div class="api hidden" id="api-decode"></div>
+      </li>
+      <li class="step" data-step="manifest">
+        <button class="step-head" aria-expanded="false" aria-controls="api-manifest">
+          <span class="num">02</span>
+          <span class="step-body"><span class="name">Poll the manifest</span><span class="detail" id="d-manifest">can-change while the job runs, then finalized</span></span>
+          <span class="state" id="s-manifest">idle</span>
+          <span class="chev" aria-hidden="true">›</span>
+        </button>
+        <div class="api hidden" id="api-manifest"></div>
+      </li>
+      <li class="step" data-step="fetch">
+        <button class="step-head" aria-expanded="false" aria-controls="api-fetch">
+          <span class="num">03</span>
+          <span class="step-body"><span class="name">Get the encrypted file</span><span class="detail" id="d-fetch">embedded JWE, or fetch the location URL</span></span>
+          <span class="state" id="s-fetch">idle</span>
+          <span class="chev" aria-hidden="true">›</span>
+        </button>
+        <div class="api hidden" id="api-fetch"></div>
+      </li>
+      <li class="step" data-step="decrypt">
+        <button class="step-head" aria-expanded="false" aria-controls="api-decrypt">
+          <span class="num">04</span>
+          <span class="step-body"><span class="name">Decrypt with your key</span><span class="detail" id="d-decrypt">AES-256-GCM, client-side</span></span>
+          <span class="state" id="s-decrypt">idle</span>
+          <span class="chev" aria-hidden="true">›</span>
+        </button>
+        <div class="api hidden" id="api-decrypt"></div>
+      </li>
+    </ol>
+
+    <div class="reveal hidden" id="reveal">
+      <div class="reveal-head">
+        <h2 id="reveal-title">Encrypted payload</h2>
+        <span class="badge locked" id="badge">locked</span>
+      </div>
+      <ul class="meta hidden" id="meta"></ul>
+      <pre id="out" class="cipher"></pre>
+    </div>
+
+    <div class="err hidden" id="error"></div>
+
+    <footer>
+      Pending jobs report <code style="font-family:var(--mono)">can-change</code>; poll until <code style="font-family:var(--mono)">finalized</code>. This viewer follows the
+      <a href="https://hl7.org/fhir/uv/smart-health-cards-and-links/STU1/links-specification.html">SMART Health Links</a> spec.
+    </footer>
+  </div>
+
+<script type="module">
+  const $ = (id) => document.getElementById(id);
+  const STEPS = ["kickoff", "decode", "manifest", "fetch", "decrypt"];
+
+  // ---- tiny QR encoder (byte mode, EC level M) --------------------------------
+  // Self-contained so the viewer needs no external library (strict CSP, no CDN).
+  const QR = (() => {
+    // Galois field tables for Reed–Solomon over GF(256), primitive poly 0x11d.
+    const EXP = new Uint8Array(512), LOG = new Uint8Array(256);
+    for (let i = 0, x = 1; i < 255; i++) { EXP[i] = x; LOG[x] = i; x <<= 1; if (x & 0x100) x ^= 0x11d; }
+    for (let i = 255; i < 512; i++) EXP[i] = EXP[i - 255];
+    const gmul = (a, b) => (a && b ? EXP[LOG[a] + LOG[b]] : 0);
+
+    // Generator polynomial ∏(x − α^i), coefficients high-degree-first (leading 1).
+    function rsGenerator(deg) {
+      let poly = [1];
+      for (let i = 0; i < deg; i++) {
+        const next = new Array(poly.length + 1).fill(0);
+        for (let j = 0; j < poly.length; j++) {
+          next[j] ^= gmul(poly[j], EXP[i]);
+          next[j + 1] ^= poly[j];
+        }
+        poly = next;
+      }
+      return poly.reverse();
+    }
+    function rsEncode(data, ecLen) {
+      const gen = rsGenerator(ecLen);   // length ecLen+1, gen[0] === 1
+      const res = new Array(ecLen).fill(0);
+      for (const d of data) {
+        const factor = d ^ res[0];
+        res.shift(); res.push(0);
+        if (factor) for (let i = 0; i < ecLen; i++) res[i] ^= gmul(gen[i + 1], factor);
+      }
+      return res;
+    }
+
+    // Per-version, EC level M: total data codewords, EC codewords/block, block counts.
+    // [version] -> { data, ecPerBlock, blocks:[[count, dataCodewords], ...] }
+    const VERSIONS = {
+      1:  { ec: 10, groups: [[1, 16]] },
+      2:  { ec: 16, groups: [[1, 28]] },
+      3:  { ec: 26, groups: [[1, 44]] },
+      4:  { ec: 18, groups: [[2, 32]] },
+      5:  { ec: 24, groups: [[2, 43]] },
+      6:  { ec: 16, groups: [[4, 27]] },
+      7:  { ec: 18, groups: [[4, 31]] },
+      8:  { ec: 22, groups: [[2, 38], [2, 39]] },
+      9:  { ec: 22, groups: [[3, 36], [2, 37]] },
+      10: { ec: 26, groups: [[4, 43], [1, 44]] },
+      11: { ec: 30, groups: [[1, 50], [4, 51]] },
+      12: { ec: 22, groups: [[6, 36], [2, 37]] },
+      13: { ec: 22, groups: [[8, 37], [1, 38]] },
+      14: { ec: 24, groups: [[4, 40], [5, 41]] },
+      15: { ec: 24, groups: [[5, 41], [5, 42]] },
+      16: { ec: 28, groups: [[7, 45], [3, 46]] },
+      17: { ec: 28, groups: [[10, 46], [1, 47]] },
+      18: { ec: 26, groups: [[9, 43], [4, 44]] },
+      19: { ec: 26, groups: [[3, 44], [11, 45]] },
+      20: { ec: 26, groups: [[3, 41], [13, 42]] },
+    };
+    const dataCapacity = (v) => VERSIONS[v].groups.reduce((n, [c, d]) => n + c * d, 0);
+
+    function pickVersion(byteLen) {
+      // Byte-mode header: 4-bit mode + 8 or 16-bit length, then 8 bits/char.
+      for (let v = 1; v <= 20; v++) {
+        const lenBits = v <= 9 ? 8 : 16;
+        const need = Math.ceil((4 + lenBits + byteLen * 8) / 8);
+        if (need <= dataCapacity(v)) return v;
+      }
+      throw new Error("Data too large for QR (max version 20).");
+    }
+
+    function buildData(bytes, v) {
+      const lenBits = v <= 9 ? 8 : 16;
+      const bits = [];
+      const push = (val, n) => { for (let i = n - 1; i >= 0; i--) bits.push((val >> i) & 1); };
+      push(0b0100, 4);            // byte mode
+      push(bytes.length, lenBits);
+      for (const b of bytes) push(b, 8);
+      const cap = dataCapacity(v) * 8;
+      push(0, Math.min(4, cap - bits.length)); // terminator
+      while (bits.length % 8) bits.push(0);
+      const codewords = [];
+      for (let i = 0; i < bits.length; i += 8) {
+        let c = 0; for (let j = 0; j < 8; j++) c = (c << 1) | bits[i + j];
+        codewords.push(c);
+      }
+      const pads = [0xec, 0x11];
+      let pi = 0;
+      while (codewords.length < dataCapacity(v)) codewords.push(pads[pi++ % 2]);
+      return codewords;
+    }
+
+    function interleave(codewords, v) {
+      const { ec, groups } = VERSIONS[v];
+      const blocks = [];
+      let pos = 0;
+      for (const [count, dlen] of groups) {
+        for (let i = 0; i < count; i++) {
+          const data = codewords.slice(pos, pos + dlen); pos += dlen;
+          blocks.push({ data, ec: rsEncode(data, ec) });
+        }
+      }
+      const maxData = Math.max(...blocks.map((b) => b.data.length));
+      const out = [];
+      for (let i = 0; i < maxData; i++) for (const b of blocks) if (i < b.data.length) out.push(b.data[i]);
+      for (let i = 0; i < ec; i++) for (const b of blocks) out.push(b.ec[i]);
+      return out;
+    }
+
+    // ---- matrix placement ----
+    const size = (v) => v * 4 + 17;
+
+    function placeFunctionPatterns(m, reserved, v) {
+      const n = size(v);
+      const finder = (r, c) => {
+        for (let dr = -1; dr <= 7; dr++) for (let dc = -1; dc <= 7; dc++) {
+          const rr = r + dr, cc = c + dc;
+          if (rr < 0 || cc < 0 || rr >= n || cc >= n) continue;
+          const inRing = dr >= 0 && dr <= 6 && dc >= 0 && dc <= 6 &&
+            (dr === 0 || dr === 6 || dc === 0 || dc === 6);
+          const inCore = dr >= 2 && dr <= 4 && dc >= 2 && dc <= 4;
+          m[rr][cc] = inRing || inCore ? 1 : 0;
+          reserved[rr][cc] = 1;
+        }
+      };
+      finder(0, 0); finder(0, n - 7); finder(n - 7, 0);
+      // timing patterns
+      for (let i = 8; i < n - 8; i++) {
+        m[6][i] = i % 2 === 0 ? 1 : 0; reserved[6][i] = 1;
+        m[i][6] = i % 2 === 0 ? 1 : 0; reserved[i][6] = 1;
+      }
+      // alignment patterns — omit the three that would collide with a finder
+      // (centers near the top-left, top-right, and bottom-left finder cores).
+      const centers = ALIGN[v] || [];
+      const last = centers.length - 1;
+      const collides = (ri, ci) =>
+        (ri === 0 && ci === 0) ||        // top-left finder
+        (ri === 0 && ci === last) ||     // top-right finder
+        (ri === last && ci === 0);       // bottom-left finder
+      for (let ri = 0; ri < centers.length; ri++) for (let ci = 0; ci < centers.length; ci++) {
+        if (collides(ri, ci)) continue;
+        const r = centers[ri], c = centers[ci];
+        for (let dr = -2; dr <= 2; dr++) for (let dc = -2; dc <= 2; dc++) {
+          const isDark = Math.max(Math.abs(dr), Math.abs(dc)) !== 1;
+          m[r + dr][c + dc] = isDark ? 1 : 0; reserved[r + dr][c + dc] = 1;
+        }
+      }
+      // dark module + reserve format/version areas
+      m[n - 8][8] = 1; reserved[n - 8][8] = 1;
+      for (let i = 0; i < 9; i++) { reserved[8][i] = 1; reserved[i][8] = 1; }
+      for (let i = 0; i < 8; i++) { reserved[8][n - 1 - i] = 1; reserved[n - 1 - i][8] = 1; }
+      if (v >= 7) {
+        for (let i = 0; i < 6; i++) for (let j = 0; j < 3; j++) {
+          reserved[i][n - 11 + j] = 1; reserved[n - 11 + j][i] = 1;
+        }
+      }
+    }
+
+    // Alignment-pattern center coordinates per version (versions 2–20).
+    const ALIGN = {
+      2: [6, 18], 3: [6, 22], 4: [6, 26], 5: [6, 30], 6: [6, 34],
+      7: [6, 22, 38], 8: [6, 24, 42], 9: [6, 26, 46], 10: [6, 28, 50],
+      11: [6, 30, 54], 12: [6, 32, 58], 13: [6, 34, 62],
+      14: [6, 26, 46, 66], 15: [6, 26, 48, 70], 16: [6, 26, 50, 74],
+      17: [6, 30, 54, 78], 18: [6, 30, 56, 82], 19: [6, 30, 58, 86],
+      20: [6, 34, 62, 90],
+    };
+
+    function placeData(m, reserved, codewords, v) {
+      const n = size(v);
+      let bitIdx = 0;
+      const totalBits = codewords.length * 8;
+      const bitAt = (i) => i < totalBits ? (codewords[i >> 3] >> (7 - (i & 7))) & 1 : 0;
+      let upward = true;
+      for (let col = n - 1; col > 0; col -= 2) {
+        if (col === 6) col--; // skip vertical timing column
+        for (let i = 0; i < n; i++) {
+          const row = upward ? n - 1 - i : i;
+          for (let c = 0; c < 2; c++) {
+            const cc = col - c;
+            if (reserved[row][cc]) continue;
+            m[row][cc] = bitAt(bitIdx++);
+          }
+        }
+        upward = !upward;
+      }
+    }
+
+    function applyMask(m, reserved, v, mask) {
+      const n = size(v);
+      const out = m.map((r) => r.slice());
+      for (let r = 0; r < n; r++) for (let c = 0; c < n; c++) {
+        if (reserved[r][c]) continue;
+        let flip = false;
+        switch (mask) {
+          case 0: flip = (r + c) % 2 === 0; break;
+          case 1: flip = r % 2 === 0; break;
+          case 2: flip = c % 3 === 0; break;
+          case 3: flip = (r + c) % 3 === 0; break;
+          case 4: flip = (Math.floor(r / 2) + Math.floor(c / 3)) % 2 === 0; break;
+          case 5: flip = ((r * c) % 2) + ((r * c) % 3) === 0; break;
+          case 6: flip = (((r * c) % 2) + ((r * c) % 3)) % 2 === 0; break;
+          case 7: flip = (((r + c) % 2) + ((r * c) % 3)) % 2 === 0; break;
+        }
+        if (flip) out[r][c] ^= 1;
+      }
+      return out;
+    }
+
+    // Format info (EC level M = 0b00) with mask, BCH(15,5) + XOR mask.
+    // bit i runs 0 (LSB) … 14 (MSB). Coordinates verified against the spec.
+    function placeFormat(m, v, mask) {
+      const n = size(v);
+      let data = (0b00 << 3) | mask;
+      let rem = data;
+      for (let i = 0; i < 10; i++) rem = (rem << 1) ^ ((rem >> 9) & 1 ? 0x537 : 0);
+      const bits = (((data << 10) | rem) ^ 0x5412);
+      const get = (i) => (bits >> i) & 1;
+      // Copy 1 — wraps the top-left finder (skipping the timing row/col at 6).
+      const tl = [
+        [8, 0, 14], [8, 1, 13], [8, 2, 12], [8, 3, 11], [8, 4, 10], [8, 5, 9],
+        [8, 7, 8], [8, 8, 7], [7, 8, 6], [5, 8, 5], [4, 8, 4], [3, 8, 3],
+        [2, 8, 2], [1, 8, 1], [0, 8, 0],
+      ];
+      for (const [r, c, i] of tl) m[r][c] = get(i);
+      // Copy 2 — bottom-left strip holds the high bits, top-right strip the low bits.
+      for (let i = 0; i < 7; i++) m[n - 1 - i][8] = get(8 + i);     // rows n-1..n-7  ← bits 8..14
+      for (let i = 0; i < 8; i++) m[8][n - 1 - i] = get(i);          // cols n-1..n-8  ← bits 0..7
+    }
+
+    function placeVersion(m, v) {
+      if (v < 7) return;
+      const n = size(v);
+      let rem = v;
+      for (let i = 0; i < 12; i++) rem = (rem << 1) ^ ((rem >> 11) & 1 ? 0x1f25 : 0);
+      const bits = (v << 12) | rem;
+      for (let i = 0; i < 18; i++) {
+        const bit = (bits >> i) & 1;
+        const r = Math.floor(i / 3), c = i % 3;
+        m[r][n - 11 + c] = bit; m[n - 11 + c][r] = bit;
+      }
+    }
+
+    function penalty(m, n) {
+      let score = 0;
+      // Rule 1: runs of 5+ same-color in rows/cols
+      for (let r = 0; r < n; r++) {
+        for (const line of [m[r], m.map((row) => row[r])]) {
+          let run = 1;
+          for (let i = 1; i < n; i++) {
+            if (line[i] === line[i - 1]) { run++; if (run === 5) score += 3; else if (run > 5) score++; }
+            else run = 1;
+          }
+        }
+      }
+      // Rule 3: finder-like 1:1:3:1:1 patterns
+      const pat = [1, 0, 1, 1, 1, 0, 1];
+      for (let r = 0; r < n; r++) for (let c = 0; c <= n - 7; c++) {
+        let h = true, vt = true;
+        for (let k = 0; k < 7; k++) { if (m[r][c + k] !== pat[k]) h = false; if (m[c + k][r] !== pat[k]) vt = false; }
+        if (h) score += 40; if (vt) score += 40;
+      }
+      return score;
+    }
+
+    function generate(text) {
+      const bytes = new TextEncoder().encode(text);
+      const v = pickVersion(bytes.length);
+      const n = size(v);
+      const codewords = interleave(buildData(bytes, v), v);
+
+      const base = Array.from({ length: n }, () => new Array(n).fill(0));
+      const reserved = Array.from({ length: n }, () => new Array(n).fill(0));
+      placeFunctionPatterns(base, reserved, v);
+      placeData(base, reserved, codewords, v);
+
+      let best = null;
+      for (let mask = 0; mask < 8; mask++) {
+        const masked = applyMask(base, reserved, v, mask);
+        placeFormat(masked, v, mask);
+        placeVersion(masked, v);
+        const p = penalty(masked, n);
+        if (!best || p < best.p) best = { matrix: masked, p, mask };
+      }
+      return best.matrix;
+    }
+
+    function draw(canvas, text) {
+      const matrix = generate(text);
+      const n = matrix.length;
+      const quiet = 4;
+      const total = n + quiet * 2;
+      canvas.width = total; canvas.height = total;
+      const ctx = canvas.getContext("2d");
+      ctx.fillStyle = "#fff"; ctx.fillRect(0, 0, total, total);
+      ctx.fillStyle = "#000";
+      for (let r = 0; r < n; r++) for (let c = 0; c < n; c++) {
+        if (matrix[r][c]) ctx.fillRect(c + quiet, r + quiet, 1, 1);
+      }
+    }
+    return { draw };
+  })();
+  const POLL_INTERVAL_MS = 2000;
+  const POLL_TIMEOUT_MS = 60000;
+
+  function setStep(step, state, detail) {
+    const el = document.querySelector(`.step[data-step="${step}"]`);
+    if (el) el.dataset.state = state;
+    const s = $(`s-${step}`);
+    if (s) s.textContent = state;
+    if (detail) $(`d-${step}`).textContent = detail;
+  }
+  function resetSteps() {
+    for (const s of STEPS) { setStep(s, "idle"); }
+    $("error").classList.add("hidden");
+    $("reveal").classList.add("hidden");
+    $("meta").classList.add("hidden");
+    $("meta").innerHTML = "";
+    seedApiTemplates();
+  }
+  function fail(step, message) {
+    setStep(step, "error");
+    const e = $("error");
+    e.innerHTML = message;
+    e.classList.remove("hidden");
+  }
+
+  // ---- per-step API panels --------------------------------------------------
+  const esc = (s) => String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const apiLog = {};   // step -> { request, response?, note?, status?, ok? }
+
+  function blocks(step) {
+    const e = apiLog[step];
+    if (!e) return '<p class="note">No call recorded yet.</p>';
+    let html = "";
+    if (e.note) html += `<p class="note">${e.note}</p>`;
+    if (e.request) {
+      html += `<div class="api-block req"><p class="api-label">Request</p><pre>${e.request}</pre></div>`;
+    }
+    if (e.response !== undefined) {
+      const cls = e.ok === false ? "status-bad" : e.status === "waiting" ? "status-wait" : "status-ok";
+      const label = e.status ? `Response · <span class="${cls}">${esc(e.status)}</span>` : "Response";
+      html += `<div class="api-block"><p class="api-label">${label}</p><pre>${e.response}</pre></div>`;
+    }
+    return html;
+  }
+  function renderApi(step) {
+    const panel = $(`api-${step}`);
+    if (panel && !panel.classList.contains("hidden")) panel.innerHTML = blocks(step);
+  }
+  function setApi(step, entry) {
+    apiLog[step] = { ...(apiLog[step] || {}), ...entry };
+    renderApi(step);
+  }
+
+  // Informative request templates before anything has run.
+  function seedApiTemplates() {
+    for (const k of Object.keys(apiLog)) delete apiLog[k];
+    apiLog.kickoff = {
+      note: 'The real kickoff is the authenticated Aidbox operation below. This demo page calls an unauthenticated stand-in on the app instead (<code>POST /demo/kickoff</code>) so no Aidbox credentials live in the browser.',
+      request:
+`<span class="verb">POST</span> /shl-app/eligibility/$kickoff
+content-type: application/fhir+json
+authorization: Basic <client:secret>
+
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    { "name": "memberName", "valueString": "…" },
+    { "name": "payerName", "valueString": "…" },
+    { "name": "memberId", "valueString": "…" }
+  ]
+}`,
+    };
+    apiLog.decode = {
+      note: 'No network call — the <code>shlink:</code> is base64url-decoded in the browser to read its <code>url</code> and <code>key</code>.',
+    };
+    apiLog.manifest = {
+      note: 'Public. Polled until <code>status: finalized</code>. If the link has the <code>P</code> flag, the body also carries <code>passcode</code> — a wrong one returns <code>401 { remainingAttempts }</code>, and too-frequent polls return <code>429</code> with <code>Retry-After</code>.',
+      request:
+`<span class="verb">POST</span> {shlink.url}
+content-type: application/json
+
+{ "recipient": "…" }`,
+    };
+    apiLog.fetch = {
+      note: 'If the manifest inlines the file as <code>embedded</code>, no call is needed. Otherwise GET the short-lived <code>location</code> URL (returns <code>application/jose</code>); an expired URL returns <code>410 Gone</code>.',
+      request: `<span class="verb">GET</span> {file.location}`,
+    };
+    apiLog.decrypt = {
+      note: 'No network call — AES-256-GCM (JWE <code>alg=dir</code>) decryption happens in the browser with the key from the link.',
+    };
+    for (const s of STEPS) renderApi(s);
+  }
+
+  // Toggle a step's API panel.
+  function toggleStep(head) {
+    const open = head.getAttribute("aria-expanded") === "true";
+    head.setAttribute("aria-expanded", String(!open));
+    const panel = $(head.getAttribute("aria-controls"));
+    const step = head.closest(".step").dataset.step;
+    panel.classList.toggle("hidden", open);
+    if (!open) renderApi(step);
+  }
+  document.querySelectorAll(".step-head").forEach((h) =>
+    h.addEventListener("click", () => toggleStep(h))
+  );
+
+  // ---- shlink decode ----
+  function b64urlToBytes(s) {
+    s = s.replace(/-/g, "+").replace(/_/g, "/");
+    while (s.length % 4) s += "=";
+    const bin = atob(s);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  }
+  function decodeShlink(input) {
+    const marker = "shlink:/";
+    const idx = input.indexOf(marker);
+    if (idx === -1) throw new Error("That doesn't look like a shlink: — no <code>shlink:/</code> marker found.");
+    const encoded = input.slice(idx + marker.length).trim();
+    const json = new TextDecoder().decode(b64urlToBytes(encoded));
+    return JSON.parse(json);
+  }
+
+  // ---- JWE (compact, alg=dir, enc=A256GCM) decryption via WebCrypto ----
+  async function decryptJwe(jwe, keyB64url) {
+    const parts = jwe.split(".");
+    if (parts.length !== 5) throw new Error("Malformed JWE (expected 5 segments).");
+    const [headerB64, , ivB64, ctB64, tagB64] = parts;
+    const header = JSON.parse(new TextDecoder().decode(b64urlToBytes(headerB64)));
+    if (header.alg !== "dir" || header.enc !== "A256GCM") {
+      throw new Error(`Unsupported JWE (alg=${header.alg}, enc=${header.enc}).`);
+    }
+    const keyBytes = b64urlToBytes(keyB64url);
+    const key = await crypto.subtle.importKey("raw", keyBytes, "AES-GCM", false, ["decrypt"]);
+    // WebCrypto expects ciphertext||tag together.
+    const ct = b64urlToBytes(ctB64), tag = b64urlToBytes(tagB64);
+    const combined = new Uint8Array(ct.length + tag.length);
+    combined.set(ct); combined.set(tag, ct.length);
+    const aad = new TextEncoder().encode(headerB64);
+    const plain = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: b64urlToBytes(ivB64), additionalData: aad },
+      key, combined
+    );
+    let text = new TextDecoder().decode(plain);
+    if (header.zip === "DEF") {
+      const ds = new DecompressionStream("deflate-raw");
+      const buf = await new Response(new Blob([plain]).stream().pipeThrough(ds)).arrayBuffer();
+      text = new TextDecoder().decode(buf);
+    }
+    return text;
+  }
+
+  // ---- tiny JSON highlighter ----
+  function highlight(jsonText) {
+    const esc = jsonText.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    return esc.replace(
+      /("(\\u[\da-fA-F]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g,
+      (m) => {
+        let cls = "n";
+        if (/^"/.test(m)) cls = /:$/.test(m) ? "k" : "s";
+        else if (/true|false/.test(m)) cls = "b";
+        else if (/null/.test(m)) cls = "b";
+        return `<span class="${cls}">${m}</span>`;
+      }
+    );
+  }
+
+  function showCipher(jwe) {
+    $("reveal").classList.remove("hidden");
+    $("reveal-title").textContent = "Encrypted payload";
+    $("badge").textContent = "locked";
+    $("badge").className = "badge locked";
+    const out = $("out");
+    out.className = "cipher";
+    out.textContent = jwe;
+  }
+  function showResult(jsonText, payload) {
+    $("reveal-title").textContent = "Decrypted result";
+    const badge = $("badge");
+    badge.textContent = "unlocked";
+    badge.className = "badge unlocked";
+    let parsed; try { parsed = JSON.parse(jsonText); } catch { parsed = null; }
+    const meta = $("meta");
+    meta.innerHTML = "";
+    const items = [];
+    if (payload.label) items.push(`<li>label <b>${payload.label}</b></li>`);
+    if (parsed?.resourceType) items.push(`<li>resource <b>${parsed.resourceType}</b></li>`);
+    if (parsed?.outcome) items.push(`<li>outcome <b>${parsed.outcome}</b></li>`);
+    if (items.length) { meta.innerHTML = items.join(""); meta.classList.remove("hidden"); }
+    const out = $("out");
+    out.className = "";
+    out.innerHTML = parsed ? highlight(JSON.stringify(parsed, null, 2)) : jsonText;
+  }
+
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  let running = false;
+
+  function setBusy(b) {
+    running = b;
+    $("start").disabled = b;
+    $("open").disabled = b;
+  }
+
+  /**
+   * Resolve a shlink: → poll the manifest → fetch the JWE → decrypt.
+   * `recipient` is the string sent in the manifest request.
+   * The kickoff step is marked done by the caller (or n/a when opening a link).
+   */
+  async function resolveAndDecrypt(raw, recipient, passcode) {
+    let payload;
+    // 01 decode (client-side, no network)
+    setStep("decode", "active");
+    try {
+      payload = decodeShlink(raw);
+      if (!payload.url || !payload.key) throw new Error("Link is missing <code>url</code> or <code>key</code>.");
+      const needsPasscode = (payload.flag || "").includes("P");
+      setStep("decode", "done", `key ${payload.key.slice(0, 6)}… · flag ${payload.flag || "—"}`);
+      setApi("decode", {
+        note: needsPasscode
+          ? "Flag includes <code>P</code> — the manifest request must carry a passcode."
+          : undefined,
+        response: JSON.stringify({ ...payload, key: payload.key.slice(0, 8) + "…(redacted)" }, null, 2),
+        status: "decoded locally",
+      });
+      if (needsPasscode && !passcode) {
+        fail("manifest", "This link has the <code>P</code> flag — enter the passcode and try again.");
+        return;
+      }
+    } catch (e) { fail("decode", e.message); return; }
+
+    // 02 poll the manifest until finalized
+    setStep("manifest", "active");
+    const reqBody = passcode ? { recipient, passcode } : { recipient };
+    const reqBodyShown = passcode ? { recipient, passcode: "••••" } : { recipient };
+    let manifest;
+    const manifestReq =
+`<span class="verb">POST</span> ${esc(payload.url)}
+content-type: application/json
+
+${JSON.stringify(reqBodyShown, null, 2)}`;
+    const deadline = Date.now() + POLL_TIMEOUT_MS;
+    let polls = 0;
+    try {
+      while (true) {
+        const res = await fetch(payload.url, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(reqBody),
+        });
+
+        // 429: server is throttling polls — honor Retry-After.
+        if (res.status === 429) {
+          const ra = parseInt(res.headers.get("retry-after") || "1", 10) || 1;
+          setApi("manifest", {
+            note: `Server throttled this poll (429). Honoring <code>Retry-After: ${ra}</code>s.`,
+            request: manifestReq,
+            response: `HTTP 429 Too Many Requests\nretry-after: ${ra}`,
+            status: "HTTP 429",
+            ok: false,
+          });
+          setStep("manifest", "active", `rate-limited · retrying in ${ra}s…`);
+          await sleep(ra * 1000);
+          continue;
+        }
+
+        // 401: passcode required or invalid.
+        if (res.status === 401) {
+          const data = await res.json().catch(() => ({}));
+          setApi("manifest", {
+            note: "Passcode rejected. The server enforces a lifetime cap on incorrect attempts.",
+            request: manifestReq,
+            response: JSON.stringify(data, null, 2),
+            status: "HTTP 401",
+            ok: false,
+          });
+          const ra = "remainingAttempts" in data
+            ? ` ${data.remainingAttempts} attempt(s) left.`
+            : "";
+          fail("manifest", `Passcode rejected.${ra}`);
+          return;
+        }
+
+        manifest = await res.json();
+        polls++;
+        setApi("manifest", {
+          note: `Public${passcode ? ", passcode-gated" : ", unauthenticated"}. Poll ${polls}${manifest.status === "finalized" ? " — finalized." : " — still " + esc(manifest.status) + ", will retry."}`,
+          request: manifestReq,
+          response: JSON.stringify(redactManifest(manifest), null, 2),
+          status: `HTTP ${res.status} · ${manifest.status}`,
+          ok: res.ok,
+        });
+        if (!res.ok) throw new Error(`Manifest request failed: HTTP ${res.status}`);
+
+        if (manifest.status === "finalized" && manifest.files?.length) {
+          setStep("manifest", "done", `finalized after ${polls} poll(s) · ${manifest.files.length} file(s)`);
+          break;
+        }
+        if (manifest.status === "no-longer-valid") {
+          throw new Error("This link is no longer valid.");
+        }
+        if (Date.now() > deadline) {
+          throw new Error(`Still ${manifest.status} after ${Math.round(POLL_TIMEOUT_MS / 1000)}s — giving up.`);
+        }
+        // can-change: job still running — keep polling.
+        setStep("manifest", "active", `can-change · polling (${polls})…`);
+        await sleep(POLL_INTERVAL_MS);
+      }
+    } catch (e) { fail("manifest", e.message); return; }
+
+    // 03 fetch the JWE (embedded or via location)
+    setStep("fetch", "active");
+    let jwe;
+    try {
+      const file = manifest.files[0];
+      if (file.embedded) {
+        jwe = file.embedded;
+        setStep("fetch", "done", "used embedded JWE");
+        setApi("fetch", {
+          note: "The manifest inlined the file as <code>embedded</code> — no extra request needed.",
+          request: undefined,
+          response: jwe.slice(0, 120) + "…  (JWE compact serialization, application/jose)",
+          status: "embedded in manifest",
+        });
+      } else if (file.location) {
+        const fr = await fetch(file.location);
+        const body = (await fr.text()).trim();
+        const gone = fr.status === 410;
+        setApi("fetch", {
+          note: gone
+            ? "The short-lived <code>location</code> URL has expired (410 Gone). Re-request the manifest for a fresh one."
+            : "Short-lived <code>location</code> URL from the manifest (expires; spec allows ≤ 1 hour).",
+          request: `<span class="verb">GET</span> ${esc(file.location)}`,
+          response: gone
+            ? body || "HTTP 410 Gone"
+            : `content-type: ${fr.headers.get("content-type") || "application/jose"}\n\n${body.slice(0, 120)}…  (JWE)`,
+          status: `HTTP ${fr.status}`,
+          ok: fr.ok,
+        });
+        if (!fr.ok) throw new Error(`File fetch failed: HTTP ${fr.status}`);
+        jwe = body;
+        setStep("fetch", "done", "fetched from location URL");
+      } else {
+        throw new Error("File entry has neither embedded nor location.");
+      }
+      showCipher(jwe);
+    } catch (e) { fail("fetch", e.message); return; }
+
+    // 04 decrypt (client-side, no network)
+    setStep("decrypt", "active");
+    try {
+      const text = await decryptJwe(jwe, payload.key);
+      setStep("decrypt", "done", "decrypted in-browser");
+      setApi("decrypt", {
+        response: "Decrypted in-browser with WebCrypto (AES-256-GCM). The plaintext FHIR resource is shown below — it never traveled over the network.",
+        status: "decrypted locally",
+      });
+      showResult(text, payload);
+    } catch (e) {
+      fail("decrypt", `Couldn't decrypt — the key may not match this file. <code>${e.message}</code>`);
+    }
+  }
+
+  // Trim the long embedded JWE in a manifest for readable display.
+  function redactManifest(m) {
+    const copy = JSON.parse(JSON.stringify(m));
+    for (const f of copy.files || []) {
+      if (f.embedded) f.embedded = f.embedded.slice(0, 48) + "…(JWE truncated)";
+    }
+    return copy;
+  }
+
+  // Start a fresh check: kickoff (step 00) → resolve/poll/decrypt.
+  async function startCheck() {
+    if (running) return;
+    resetSteps();
+    $("linkbox").classList.add("hidden");
+    $("qrbox").classList.add("hidden");
+    setBusy(true);
+
+    setStep("kickoff", "active");
+    let shlink;
+    const recipient = $("recipient").value.trim() || "SHL Viewer (demo)";
+    const passcode = $("passcode").value.trim();
+    const kickBody = {
+      memberName: $("memberName").value.trim(),
+      payerName: $("payerName").value.trim(),
+      memberId: $("memberId").value.trim(),
+      ...(passcode ? { passcode } : {}),
+    };
+    try {
+      const res = await fetch("/demo/kickoff", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(kickBody),
+      });
+      const data = await res.json();
+      const kickoffParams = {
+        resourceType: "Parameters",
+        parameter: [
+          { name: "memberName", valueString: kickBody.memberName },
+          { name: "payerName", valueString: kickBody.payerName },
+          { name: "memberId", valueString: kickBody.memberId },
+          ...(passcode ? [{ name: "passcode", valueString: "••••" }] : []),
+        ],
+      };
+      setApi("kickoff", {
+        note: `The real kickoff is the authenticated Aidbox operation shown below. This demo page can't hold Aidbox credentials in the browser, so it actually called an unauthenticated stand-in on the app: <code>POST /demo/kickoff</code>.${passcode ? " A passcode was supplied, so the link gets the <code>P</code> flag." : ""}`,
+        request:
+`<span class="verb">POST</span> /shl-app/eligibility/$kickoff
+content-type: application/fhir+json
+authorization: Basic <client:secret>
+
+${JSON.stringify(kickoffParams, null, 2)}`,
+        response: JSON.stringify(
+          data.shlink ? { ...data, shlink: data.shlink.split("shlink:/")[0] + "shlink:/…(payload)" } : data,
+          null, 2),
+        status: `HTTP ${res.status}`,
+        ok: res.ok,
+      });
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      shlink = data.shlink;
+      setStep("kickoff", "done", passcode ? "job started · P flag" : "job started");
+      $("shlink-out").textContent = shlink;
+      $("linkbox").classList.remove("hidden");
+      showQr(shlink);
+    } catch (e) { fail("kickoff", `Couldn't start the check — <code>${e.message}</code>`); setBusy(false); return; }
+
+    await resolveAndDecrypt(shlink, recipient, passcode);
+    setBusy(false);
+  }
+
+  // Open an existing link: skip kickoff, just resolve/decrypt.
+  async function openLink() {
+    if (running) return;
+    resetSteps();
+    setStep("kickoff", "done", "n/a — opened an existing link");
+    const raw = $("shl").value.trim();
+    if (!raw) { fail("decode", "Paste a <code>shlink:</code> first."); return; }
+    setBusy(true);
+    const recipient = $("recipient-open-input").value.trim() || "SHL Viewer (demo)";
+    const passcode = $("passcode-open").value.trim();
+    await resolveAndDecrypt(raw, recipient, passcode);
+    setBusy(false);
+  }
+
+  // ---- tabs ----
+  function selectTab(which) {
+    const start = which === "start";
+    $("tab-start").setAttribute("aria-selected", String(start));
+    $("tab-open").setAttribute("aria-selected", String(!start));
+    $("pane-start").classList.toggle("hidden", !start);
+    $("pane-open").classList.toggle("hidden", start);
+  }
+  $("tab-start").addEventListener("click", () => selectTab("start"));
+  $("tab-open").addEventListener("click", () => selectTab("open"));
+
+  $("start").addEventListener("click", startCheck);
+  $("open").addEventListener("click", openLink);
+  $("clear").addEventListener("click", () => { $("shl").value = ""; resetSteps(); });
+  // Render the minted link as a scannable QR code.
+  function showQr(shlink) {
+    try {
+      QR.draw($("qr"), shlink);
+      $("qrbox").classList.remove("hidden");
+    } catch (e) {
+      // Link too long to encode — keep the textual link, skip the QR.
+      $("qrbox").classList.add("hidden");
+    }
+  }
+
+  $("copy").addEventListener("click", async () => {
+    try { await navigator.clipboard.writeText($("shlink-out").textContent); $("copy").textContent = "Copied"; setTimeout(() => ($("copy").textContent = "Copy"), 1200); }
+    catch { /* clipboard may be blocked; ignore */ }
+  });
+
+  // Seed the API panels with request templates so they're informative pre-run.
+  seedApiTemplates();
+
+  // Prefill from the URL fragment (viewer-URL form: …/#shlink:/…) or ?shlink=
+  const frag = location.hash.slice(1);
+  const q = new URLSearchParams(location.search).get("shlink");
+  const prefill = (frag && frag.includes("shlink:/")) ? frag : (q || "");
+  if (prefill) { selectTab("open"); $("shl").value = decodeURIComponent(prefill); openLink(); }
+</script>
+</body>
+</html>

--- a/aidbox-integrations/smart-health-link/src/viewer.html
+++ b/aidbox-integrations/smart-health-link/src/viewer.html
@@ -145,7 +145,7 @@
   .grid2 .span2 { grid-column: 1 / -1; }
   @media (max-width: 520px) { .grid2 { grid-template-columns: 1fr; } }
   .opt { color: var(--muted); font-weight: 400; text-transform: none; letter-spacing: 0; }
-  input[type="text"] {
+  input[type="text"], select {
     width: 100%;
     background: var(--ground);
     color: var(--text);
@@ -155,7 +155,8 @@
     font-family: var(--sans);
     font-size: 14px;
   }
-  input[type="text"]:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+  input[type="text"]:focus-visible, select:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+  input[readonly] { color: var(--muted); cursor: default; }
 
   /* ---- minted link box ---- */
   .linkbox {
@@ -310,6 +311,12 @@
   }
   .badge.locked { color: var(--locked); border-color: var(--locked); }
   .badge.unlocked { color: var(--accent); border-color: var(--accent); }
+  .verdict {
+    margin: 0 0 14px; padding: 12px 14px; border-radius: 10px;
+    font-size: 14px; font-weight: 600; border: 1px solid;
+  }
+  .verdict.eligible { color: var(--accent); border-color: var(--accent); background: rgba(94,234,212,.08); }
+  .verdict.ineligible { color: var(--danger); border-color: var(--danger); background: rgba(244,113,116,.08); }
 
   pre {
     margin: 0;
@@ -371,26 +378,23 @@
 
       <!-- Mode: start a check -->
       <div class="pane" id="pane-start">
-        <div class="grid2">
+        <label class="fld" for="scenario">Member</label>
+        <select id="scenario">
+          <option value="eligible">Eligible: Jane Prospect (Acme Health)</option>
+          <option value="ineligible">Not eligible: John Doe (Acme Health)</option>
+        </select>
+        <div class="grid2" style="margin-top:14px">
           <div>
             <label class="fld" for="memberName">Member name</label>
-            <input id="memberName" type="text" value="Jane Prospect" spellcheck="false" />
+            <input id="memberName" type="text" readonly />
           </div>
           <div>
             <label class="fld" for="payerName">Payer</label>
-            <input id="payerName" type="text" value="Acme Health" spellcheck="false" />
+            <input id="payerName" type="text" readonly />
           </div>
           <div>
             <label class="fld" for="memberId">Member ID</label>
-            <input id="memberId" type="text" value="M-99887" spellcheck="false" />
-          </div>
-          <div>
-            <label class="fld" for="recipient">Recipient (you)</label>
-            <input id="recipient" type="text" value="SHL Viewer (demo)" spellcheck="false" />
-          </div>
-          <div class="span2">
-            <label class="fld" for="passcode">Passcode <span class="opt">(optional, adds the P flag)</span></label>
-            <input id="passcode" type="text" value="" placeholder="leave empty for an L-only link" spellcheck="false" />
+            <input id="memberId" type="text" readonly />
           </div>
         </div>
         <div class="row">
@@ -404,8 +408,8 @@
         <textarea id="shl" placeholder="shlink:/eyJ1cmwiOiJodHRw…  (or a viewer URL containing one)" spellcheck="false"></textarea>
         <div class="grid2" style="margin-top:14px">
           <div>
-            <label class="fld" for="passcode-open">Passcode <span class="opt">(if the link has the P flag)</span></label>
-            <input id="passcode-open" type="text" value="" placeholder="only if required" spellcheck="false" />
+            <label class="fld" for="passcode-open">Passcode <span class="opt">(only if the link is locked)</span></label>
+            <input id="passcode-open" type="text" value="" placeholder="only if the link is locked" spellcheck="false" />
           </div>
           <div>
             <label class="fld" for="recipient-open-input">Recipient (you)</label>
@@ -425,15 +429,12 @@
         <h2 id="reveal-title">Encrypted payload</h2>
         <span class="badge locked" id="badge">locked</span>
       </div>
+      <div class="verdict hidden" id="verdict"></div>
       <ul class="meta hidden" id="meta"></ul>
       <pre id="out" class="cipher"></pre>
     </div>
 
-    <!-- Behind the scenes: the minted link, its QR, and the HTTP steps -->
-    <button class="bts-toggle" id="bts-toggle" type="button" aria-expanded="true">Behind the scenes <span class="bts-chev" aria-hidden="true">›</span></button>
-    <div class="bts" id="bts">
-
-    <!-- Minted link, shown after kickoff -->
+    <!-- The link this check produced (the SHL artifact) -->
     <div class="linkbox hidden" id="linkbox">
       <span class="linkbox-label">Your SMART Health Link</span>
       <code id="shlink-out"></code>
@@ -443,15 +444,18 @@
     <!-- QR encoding of the link, shown after kickoff -->
     <div class="qrbox hidden" id="qrbox">
       <canvas id="qr" width="140" height="140" aria-label="QR code for the SMART Health Link"></canvas>
-      <p class="qr-caption">Scan with a <b>SMART Health Links</b> wallet to open it on a phone. The QR holds the same <code>shlink:</code>, key included, so treat it as a secret.</p>
+      <p class="qr-caption">The QR holds the same <code>shlink:</code>, key included, so treat it as a secret.</p>
     </div>
 
+    <!-- Behind the scenes: the HTTP steps -->
+    <button class="bts-toggle" id="bts-toggle" type="button" aria-expanded="true">Behind the scenes <span class="bts-chev" aria-hidden="true">›</span></button>
+    <div class="bts" id="bts">
     <ol class="steps" id="steps">
       <li class="step" data-step="kickoff" data-where="server">
         <button class="step-head" aria-expanded="false" aria-controls="api-kickoff">
           <span class="num">01</span>
-          <span class="step-body"><span class="name">Start the check</span><span class="detail" id="d-kickoff">mint a shlink: and begin the eligibility job</span></span>
-          <span class="where server">server</span>
+          <span class="step-body"><span class="name">Start the check</span><span class="detail" id="d-kickoff">the backend mints the link and starts the eligibility job</span></span>
+          <span class="where server">Aidbox → backend</span>
           <span class="state" id="s-kickoff">idle</span>
           <span class="chev" aria-hidden="true">›</span>
         </button>
@@ -460,7 +464,7 @@
       <li class="step" data-step="decode" data-where="browser">
         <button class="step-head" aria-expanded="false" aria-controls="api-decode">
           <span class="num">02</span>
-          <span class="step-body"><span class="name">Read the link</span><span class="detail" id="d-decode">decode url + key from the shlink: payload</span></span>
+          <span class="step-body"><span class="name">Read the link</span><span class="detail" id="d-decode">pull the Aidbox manifest URL + the decryption key out of the link</span></span>
           <span class="where browser">browser</span>
           <span class="state" id="s-decode">idle</span>
           <span class="chev" aria-hidden="true">›</span>
@@ -470,8 +474,8 @@
       <li class="step" data-step="manifest" data-where="server">
         <button class="step-head" aria-expanded="false" aria-controls="api-manifest">
           <span class="num">03</span>
-          <span class="step-body"><span class="name">Wait for the eligibility result</span><span class="detail" id="d-manifest">the server is checking your coverage with the payer; poll until it's ready</span></span>
-          <span class="where server">server</span>
+          <span class="step-body"><span class="name">Wait for the eligibility result</span><span class="detail" id="d-manifest">poll Aidbox until the result is ready (the backend is checking the payer)</span></span>
+          <span class="where server">Aidbox → backend</span>
           <span class="state" id="s-manifest">idle</span>
           <span class="chev" aria-hidden="true">›</span>
         </button>
@@ -480,8 +484,8 @@
       <li class="step" data-step="fetch" data-where="server">
         <button class="step-head" aria-expanded="false" aria-controls="api-fetch">
           <span class="num">04</span>
-          <span class="step-body"><span class="name">Download the result</span><span class="detail" id="d-fetch">encrypted (JWE), embedded or via a location URL</span></span>
-          <span class="where server">server</span>
+          <span class="step-body"><span class="name">Download the result</span><span class="detail" id="d-fetch">fetch the encrypted result (JWE) from Aidbox</span></span>
+          <span class="where server">Aidbox → backend</span>
           <span class="state" id="s-fetch">idle</span>
           <span class="chev" aria-hidden="true">›</span>
         </button>
@@ -820,12 +824,13 @@
     if (el) el.dataset.state = state;
     const s = $(`s-${step}`);
     if (s) s.textContent = state;
-    if (detail) $(`d-${step}`).textContent = detail;
+    if (detail) { const d = $(`d-${step}`); if (d) d.textContent = detail; }
   }
   function resetSteps() {
     for (const s of STEPS) { setStep(s, "idle"); }
     $("error").classList.add("hidden");
     $("reveal").classList.add("hidden");
+    $("verdict").classList.add("hidden");
     $("meta").classList.add("hidden");
     $("meta").innerHTML = "";
     seedApiTemplates();
@@ -985,6 +990,7 @@ content-type: application/json
     $("reveal-title").textContent = "Encrypted payload";
     $("badge").textContent = "locked";
     $("badge").className = "badge locked";
+    $("verdict").classList.add("hidden");
     const out = $("out");
     out.className = "cipher";
     out.textContent = jwe;
@@ -995,6 +1001,14 @@ content-type: application/json
     badge.textContent = "unlocked";
     badge.className = "badge unlocked";
     let parsed; try { parsed = JSON.parse(jsonText); } catch { parsed = null; }
+    const verdict = $("verdict");
+    const inforce = parsed?.insurance?.[0]?.inforce;
+    if (inforce === true || inforce === false) {
+      verdict.className = "verdict " + (inforce ? "eligible" : "ineligible");
+      verdict.textContent = (inforce ? "✓ " : "✕ ") + (parsed.disposition || (inforce ? "Eligible" : "Not eligible"));
+    } else {
+      verdict.className = "verdict hidden";
+    }
     const meta = $("meta");
     meta.innerHTML = "";
     const items = [];
@@ -1033,7 +1047,7 @@ content-type: application/json
       setApi("decode", {
         note: needsPasscode
           ? "Flag includes <code>P</code>, so the manifest request must carry a passcode."
-          : undefined,
+          : "A <code>shlink:</code> is just an opaque string. The browser unpacks it to get the two things the rest of the flow needs: the <code>url</code> (the Aidbox manifest, polled in step 03) and the <code>key</code> (used to decrypt the result in step 05). No network call; everything here is read from the link itself.",
         response: JSON.stringify({ ...payload, key: payload.key.slice(0, 8) + "…(redacted)" }, null, 2),
         status: "decoded locally",
       });
@@ -1055,6 +1069,7 @@ content-type: application/json
 ${JSON.stringify(reqBodyShown, null, 2)}`;
     const deadline = Date.now() + POLL_TIMEOUT_MS;
     let polls = 0;
+    const pollLines = [];
     try {
       while (true) {
         const res = await fetch(payload.url, {
@@ -1097,10 +1112,11 @@ ${JSON.stringify(reqBodyShown, null, 2)}`;
 
         manifest = await res.json();
         polls++;
+        pollLines.push(`poll ${polls}: HTTP ${res.status} → ${manifest.status}`);
         setApi("manifest", {
-          note: `Public${passcode ? ", passcode-gated" : ", unauthenticated"}. Poll ${polls}${manifest.status === "finalized" ? ", finalized." : ", still " + esc(manifest.status) + ", will retry."}`,
+          note: `The browser POSTs the manifest URL on Aidbox (public, no auth) with body <code>{ recipient }</code>, then re-polls until the status is <code>finalized</code>. Every poll's outcome is listed below.`,
           request: manifestReq,
-          response: JSON.stringify(redactManifest(manifest), null, 2),
+          response: pollLines.join("\n") + "\n\n" + JSON.stringify(redactManifest(manifest), null, 2),
           status: `HTTP ${res.status} · ${manifest.status}`,
           ok: res.ok,
         });
@@ -1131,7 +1147,7 @@ ${JSON.stringify(reqBodyShown, null, 2)}`;
         jwe = file.embedded;
         setStep("fetch", "done", "used embedded JWE");
         setApi("fetch", {
-          note: "The manifest inlined the file as <code>embedded</code>, so no extra request is needed.",
+          note: "The encrypted result came back inside the manifest itself (its <code>embedded</code> field), so the browser already has it and skips a separate download. Small files are inlined like this; large ones come back as a <code>location</code> URL to GET instead.",
           request: undefined,
           response: jwe.slice(0, 120) + "…  (JWE compact serialization, application/jose)",
           status: "embedded in manifest",
@@ -1184,7 +1200,7 @@ ${JSON.stringify(reqBodyShown, null, 2)}`;
     return copy;
   }
 
-  // Start a fresh check: kickoff (step 00) → resolve/poll/decrypt.
+  // Start a fresh check: kickoff (step 01) → resolve/poll/decrypt.
   async function startCheck() {
     if (running) return;
     resetSteps();
@@ -1194,13 +1210,12 @@ ${JSON.stringify(reqBodyShown, null, 2)}`;
 
     setStep("kickoff", "active");
     let shlink;
-    const recipient = $("recipient").value.trim() || "SHL Viewer (demo)";
-    const passcode = $("passcode").value.trim();
+    const recipient = "SHL Viewer (demo)";
     const kickBody = {
-      memberName: $("memberName").value.trim(),
-      payerName: $("payerName").value.trim(),
-      memberId: $("memberId").value.trim(),
-      ...(passcode ? { passcode } : {}),
+      memberName: $("memberName").value,
+      payerName: $("payerName").value,
+      memberId: $("memberId").value,
+      eligible: $("scenario").value !== "ineligible",
     };
     try {
       const res = await fetch("/demo/kickoff", {
@@ -1215,11 +1230,10 @@ ${JSON.stringify(reqBodyShown, null, 2)}`;
           { name: "memberName", valueString: kickBody.memberName },
           { name: "payerName", valueString: kickBody.payerName },
           { name: "memberId", valueString: kickBody.memberId },
-          ...(passcode ? [{ name: "passcode", valueString: "••••" }] : []),
         ],
       };
       setApi("kickoff", {
-        note: `The real kickoff is the authenticated Aidbox operation shown below. This demo page can't hold Aidbox credentials in the browser, so it actually called an unauthenticated stand-in on the app: <code>POST /demo/kickoff</code>.${passcode ? " A passcode was supplied, so the link gets the <code>P</code> flag." : ""}`,
+        note: `The real kickoff is the authenticated Aidbox operation shown below. This demo page can't hold Aidbox credentials in the browser, so it actually called an unauthenticated stand-in on the app: <code>POST /demo/kickoff</code>.`,
         request:
 `<span class="verb">POST</span> /shl-app/eligibility/$kickoff
 content-type: application/fhir+json
@@ -1234,13 +1248,13 @@ ${JSON.stringify(kickoffParams, null, 2)}`,
       });
       if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
       shlink = data.shlink;
-      setStep("kickoff", "done", passcode ? "job started · P flag" : "job started");
+      setStep("kickoff", "done", "job started");
       $("shlink-out").textContent = shlink;
       $("linkbox").classList.remove("hidden");
       showQr(shlink);
     } catch (e) { fail("kickoff", `Couldn't start the check. <code>${e.message}</code>`); setBusy(false); return; }
 
-    await resolveAndDecrypt(shlink, recipient, passcode);
+    await resolveAndDecrypt(shlink, recipient);
     setBusy(false);
   }
 
@@ -1248,7 +1262,6 @@ ${JSON.stringify(kickoffParams, null, 2)}`,
   async function openLink() {
     if (running) return;
     resetSteps();
-    setStep("kickoff", "done", "n/a, opened an existing link");
     const raw = $("shl").value.trim();
     if (!raw) { fail("decode", "Paste a <code>shlink:</code> first."); return; }
     setBusy(true);
@@ -1265,8 +1278,9 @@ ${JSON.stringify(kickoffParams, null, 2)}`,
     $("tab-open").setAttribute("aria-selected", String(!start));
     $("pane-start").classList.toggle("hidden", !start);
     $("pane-open").classList.toggle("hidden", start);
-    // Step 00 (kickoff) only applies when you start a check; hide it when opening an existing link.
-    document.querySelector('.step[data-step="kickoff"]').classList.toggle("hidden", !start);
+    // "Start the check" (kickoff) only happens when you start a check, not when opening an existing link.
+    const k = document.querySelector('.step[data-step="kickoff"]');
+    if (k) k.classList.toggle("hidden", !start);
   }
   $("tab-start").addEventListener("click", () => selectTab("start"));
   $("tab-open").addEventListener("click", () => selectTab("open"));
@@ -1279,6 +1293,21 @@ ${JSON.stringify(kickoffParams, null, 2)}`,
 
   $("start").addEventListener("click", startCheck);
   $("open").addEventListener("click", openLink);
+
+  // Preset member data per scenario; the fields are read-only and just show
+  // who the selected scenario stands for.
+  const PRESETS = {
+    eligible:   { memberName: "Jane Prospect", payerName: "Acme Health", memberId: "M-99887" },
+    ineligible: { memberName: "John Doe",      payerName: "Acme Health", memberId: "M-55501" },
+  };
+  function fillScenarioFields() {
+    const p = PRESETS[$("scenario").value] || PRESETS.eligible;
+    $("memberName").value = p.memberName;
+    $("payerName").value = p.payerName;
+    $("memberId").value = p.memberId;
+  }
+  $("scenario").addEventListener("change", fillScenarioFields);
+  fillScenarioFields();
   $("clear").addEventListener("click", () => { $("shl").value = ""; resetSteps(); });
   // Render the minted link as a scannable QR code.
   function showQr(shlink) {

--- a/aidbox-integrations/smart-health-link/tsconfig.json
+++ b/aidbox-integrations/smart-health-link/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "types": ["@types/bun"],
+
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Adds an Aidbox-integrated **SMART Health Links (SHL)** example built on Bun + TypeScript. It securely shares the result of a long-running **real-time eligibility (RTE)** check with an **unauthenticated** client:

1. Client kicks off the check → receives a `shlink:` carrying an encryption key
2. Polls a manifest (`can-change` → `finalized`) while the async job runs
3. Fetches the encrypted file (JWE, `alg: dir` / `enc: A256GCM`) and decrypts it client-side

The SHL key is the only secret — the server stores only ciphertext.

## What's included

- **Bun + TypeScript service** — native `Bun.serve`, no build step. Mints links, runs the async RTE job, manages manifest lifecycle, delivers the encrypted file.
- **Aidbox integration** — init bundle with a `SHLink` custom resource and an `shl-app` App routing `$kickoff` (authenticated), `manifest/{shlId}`, and `file/{fileId}` (public).
- **Self-contained browser viewer** (`src/viewer.html`, served at `GET /`) — resolves a `shlink:` and decrypts it with WebCrypto, with a step-by-step view of each HTTP call behind the flow.
- **QR code** — the viewer renders the minted link as a scannable QR via an inline, dependency-free QR encoder (byte mode, EC level M, versions 1–20), so a phone wallet can pick up the link. No CDN — satisfies the viewer's strict CSP.

## Output

A FHIR `CoverageEligibilityResponse`, encrypted as a JWE.

## Verification

- `bunx tsc --noEmit` passes.
- Full stack runs via `docker compose up --build` (Aidbox + app); kickoff mints links and the viewer decrypts the result.
- The QR encoder was round-trip tested against an independent decoder across every version 1–13 (including realistic ~300-char shlink payloads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)