### PR TITLE
Add init-bundle-from-directories example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A collection of examples on top of Aidbox FHIR platform
 - [AWS S3 Aidbox integration](aidbox-features/aws-s3-aidbox-integration/)
 - [Medicare Plan Finder (MPF)](aidbox-features/medicare-plan-finder/)
 - [Init bundle with environment template](aidbox-features/init-bundle-env-template/)
+- [Init bundle from resource directories](aidbox-features/init-bundle-from-directories/)
 - [OpenTelemetry](aidbox-features/OpenTelemetry/)
 - [Organization-Based Access Control (OrgBAC) Practitioner Application](aidbox-features/orgbac-practitioner-application/)
 - [SMART App Launch with Aidbox and Keycloak](aidbox-features/smart-app-launch/)

--- a/aidbox-features/init-bundle-from-directories/.github/workflows/build-init-bundle.yml
+++ b/aidbox-features/init-bundle-from-directories/.github/workflows/build-init-bundle.yml
@@ -1,0 +1,42 @@
+# Illustrative workflow for this example — NOT run by this repository.
+# GitHub only runs workflows placed in `.github/workflows/` at the REPOSITORY
+# ROOT. To use it in your own project, copy this file there and adjust the
+# `paths:` values to match where you keep the sources.
+#
+# What it does: builds the custom IG, then one init bundle per environment, and
+# uploads them all as workflow artifacts.
+name: build-init-bundle
+
+on:
+  push:
+    paths:
+      - 'ig/**'
+      - 'common/**'
+      - 'dev/**'
+      - 'qa/**'
+      - 'prod/**'
+      - 'build-ig.sh'
+      - 'build-init-bundle.sh'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build the custom IG
+        run: ./build-ig.sh
+
+      # jq is preinstalled on GitHub runners.
+      - name: Build an init bundle per environment
+        run: |
+          for env in dev qa prod; do
+            ./build-init-bundle.sh "$env" "dist/init-bundle.$env.json"
+          done
+
+      - name: Upload artifacts (IG tarball + per-environment bundles)
+        uses: actions/upload-artifact@v4
+        with:
+          name: init-bundles
+          path: dist/

--- a/aidbox-features/init-bundle-from-directories/.gitignore
+++ b/aidbox-features/init-bundle-from-directories/.gitignore
@@ -1,0 +1,3 @@
+# Generated artifacts — build them locally or in CI, don't commit them.
+# build-init-bundle.sh -> dist/init-bundle*.json ; build-ig.sh -> dist/custom-ig.tgz
+dist/

--- a/aidbox-features/init-bundle-from-directories/Makefile
+++ b/aidbox-features/init-bundle-from-directories/Makefile
@@ -1,0 +1,20 @@
+ENV ?= dev
+
+.PHONY: build up down clean logs
+
+build:
+	./build-ig.sh
+	./build-init-bundle.sh $(ENV)
+
+up: build
+	docker compose up
+
+down:
+	docker compose down
+
+clean:
+	docker compose down -v
+	rm -rf dist
+
+logs:
+	docker compose logs -f aidbox

--- a/aidbox-features/init-bundle-from-directories/README.md
+++ b/aidbox-features/init-bundle-from-directories/README.md
@@ -20,11 +20,22 @@ dev/                                 # → dev only (full demo/seed data)
 └── 05_Organization/ 06_Practitioner/ 07_Patient/ 08_Observation/ 09_ClinicalSnippet/
 qa/                                  # → qa only (minimal smoke subset)
 └── 05_Organization/ 07_Patient/
-prod/                                # → prod only (empty: prod = common only)
+prod/                                # → prod only (ops-monitor Client, prod-only)
+└── 03_Client/
 ```
 
-A bundle for an environment is `common/` + that environment's own folder, so
-the tree shows exactly what each env gets: `dev` = common + dev, `prod` = common.
+A bundle for an environment is `common/` + that environment's own folder, so the
+tree shows exactly what each env gets — `dev` = common + dev, `prod` = common + prod:
+
+```mermaid
+flowchart LR
+  common["common/ (config, all envs)"] --> devb & qab & prodb
+  dev["dev/ (full demo)"] --> devb["init-bundle.dev.json"]
+  qa["qa/ (smoke subset)"] --> qab["init-bundle.qa.json"]
+  prod["prod/ (ops client)"] --> prodb["init-bundle.prod.json"]
+```
+
+And the build/load pipeline:
 
 ```mermaid
 flowchart LR

--- a/aidbox-features/init-bundle-from-directories/README.md
+++ b/aidbox-features/init-bundle-from-directories/README.md
@@ -1,0 +1,79 @@
+---
+features: [Configuration, Init bundle, Seed data, Custom resource, Custom FHIR IG, AccessPolicy, Client, App, CI/CD]
+languages: [Shell, YAML]
+---
+
+# Init Bundle from Resource Directories
+
+Compile a directory of per-resource-type JSON files into one Aidbox
+[init bundle](https://www.health-samurai.io/docs/aidbox/configuration/init-bundle.md)
+(config + seed data) that loads at startup — instead of a hand-ordered script
+that POSTs resources one by one after boot.
+
+```
+ig/package/                          # source of the custom FHIR IG
+common/                              # → EVERY environment (config)
+├── 00_packages/                     #   installs the local custom IG ($fhir-package-install)
+├── 01_StructureDefinition/          #   custom resource TYPE (ClinicalSnippet)
+├── 02_App/  03_Client/  04_AccessPolicy/
+dev/                                 # → dev only (full demo/seed data)
+└── 05_Organization/ 06_Practitioner/ 07_Patient/ 08_Observation/ 09_ClinicalSnippet/
+qa/                                  # → qa only (minimal smoke subset)
+└── 05_Organization/ 07_Patient/
+prod/                                # → prod only (empty: prod = common only)
+```
+
+A bundle for an environment is `common/` + that environment's own folder, so
+the tree shows exactly what each env gets: `dev` = common + dev, `prod` = common.
+
+## Run
+
+Needs `jq`.
+
+```bash
+./build-ig.sh                # -> dist/custom-ig.tgz
+./build-init-bundle.sh dev   # -> dist/init-bundle.json (common + dev)
+docker compose up            # Aidbox loads it at startup; activate on first launch
+```
+
+Build another environment: `./build-init-bundle.sh prod` (common only, no demo).
+
+## How it works
+
+`build-init-bundle.sh <env>` collects the `*.json` under `common/` and `<env>/`
+and `jq`-wraps each into one `batch` bundle:
+
+- **`PUT <type>/<id>`**, idempotent — Aidbox de-dupes identical PUTs, so a re-run
+  is a no-op and doesn't grow history.
+- **Ordering = directory number** (`common/` is 00–04, env data 05+): `00_packages`
+  (custom IG) and `01_StructureDefinition` (custom types) run first; env data last.
+- **A `Parameters` resource** is a package install → `POST $fhir-package-install`
+  (bundle-relative url, *not* `/fhir/$fhir-package-install`).
+
+## Packages
+
+- **Published IGs (us.core)** → `BOX_BOOTSTRAP_FHIR_PACKAGES` in
+  `docker-compose.yaml`. Runs **only on first startup** (fresh DB).
+- **Local custom IG** → built by `build-ig.sh`, installed in the bundle via
+  `$fhir-package-install` (`file://` to the mounted `.tgz`). Its `MyOrgPatient`
+  profile derives from `us-core-patient`.
+
+## Custom resource type
+
+`common/01_StructureDefinition/clinical-snippet.json` defines `ClinicalSnippet`
+(`derivation: specialization` → its own table). It's registered **and** an
+instance seeded in the same bundle (verified: `GET /fhir/ClinicalSnippet/snippet-welcome`).
+
+## Notes
+
+- **Secrets / per-env values** are out of scope — a committed bundle must not
+  carry secrets. Inject them at container start; see
+  [init-bundle-env-template](../init-bundle-env-template/).
+- **Delivering the bundle to a pod** (image / ConfigMap / init container / URL):
+  see the [init bundle docs](https://www.health-samurai.io/docs/aidbox/configuration/init-bundle).
+- **CI** (`.github/workflows/build-init-bundle.yml`) is illustrative — GitHub
+  only runs workflows at the repo root, so copy it there. It just builds the IG
+  and one bundle per environment and uploads `dist/`.
+
+`dist/` is generated (`.gitignore`d); commit `ig/`, `common/`, `dev/`, `qa/`,
+`prod/`, and the two build scripts.

--- a/aidbox-features/init-bundle-from-directories/README.md
+++ b/aidbox-features/init-bundle-from-directories/README.md
@@ -47,15 +47,22 @@ flowchart LR
 
 ## Run
 
-Needs `jq`.
+Needs `jq`. With `make`:
+
+```bash
+make up            # build (dev) + start Aidbox; activate on first launch
+make up ENV=prod   # build & run another environment
+make down          # stop (keep the database)
+make clean         # stop + wipe the database and dist/
+```
+
+Or step by step:
 
 ```bash
 ./build-ig.sh                # -> dist/custom-ig.tgz
 ./build-init-bundle.sh dev   # -> dist/init-bundle.json (common + dev)
 docker compose up            # Aidbox loads it at startup; activate on first launch
 ```
-
-Build another environment: `./build-init-bundle.sh prod` (common only, no demo).
 
 ## How it works
 

--- a/aidbox-features/init-bundle-from-directories/README.md
+++ b/aidbox-features/init-bundle-from-directories/README.md
@@ -26,6 +26,14 @@ prod/                                # → prod only (empty: prod = common only)
 A bundle for an environment is `common/` + that environment's own folder, so
 the tree shows exactly what each env gets: `dev` = common + dev, `prod` = common.
 
+```mermaid
+flowchart LR
+  ig["ig/package/"] -->|build-ig.sh| tgz["dist/custom-ig.tgz"]
+  res["common/ + env/"] -->|build-init-bundle.sh env| bundle["dist/init-bundle.json"]
+  tgz --> box
+  bundle -->|BOX_INIT_BUNDLE| box["Aidbox: applies the bundle before HTTP opens"]
+```
+
 ## Run
 
 Needs `jq`.
@@ -47,8 +55,9 @@ and `jq`-wraps each into one `batch` bundle:
   is a no-op and doesn't grow history.
 - **Ordering = directory number** (`common/` is 00–04, env data 05+): `00_packages`
   (custom IG) and `01_StructureDefinition` (custom types) run first; env data last.
-- **A `Parameters` resource** is a package install → `POST $fhir-package-install`
-  (bundle-relative url, *not* `/fhir/$fhir-package-install`).
+- **A file with its own `request`** is used as a bundle entry verbatim — how the
+  `$fhir-package-install` operation is expressed (bundle-relative url, *not*
+  `/fhir/$fhir-package-install`). Bare resource files → `PUT` by id.
 
 ## Packages
 
@@ -64,6 +73,18 @@ and `jq`-wraps each into one `batch` bundle:
 (`derivation: specialization` → its own table). It's registered **and** an
 instance seeded in the same bundle (verified: `GET /fhir/ClinicalSnippet/snippet-welcome`).
 
+## CI
+
+[`.github/workflows/build-init-bundle.yml`](.github/workflows/build-init-bundle.yml)
+runs `build-ig.sh` and builds one bundle per environment
+(`dist/init-bundle.<env>.json`), then uploads `dist/` as artifacts. It only
+**builds** the bundles — it doesn't boot Aidbox or deploy; delivering them to a
+pod is a separate step (see Notes).
+
+It's illustrative: GitHub only runs workflows placed at the **repository root**
+`.github/workflows/`, so this copy inside the example folder never runs here —
+copy it to your repo root (and adjust `paths:`) to use it.
+
 ## Notes
 
 - **Secrets / per-env values** are out of scope — a committed bundle must not
@@ -71,9 +92,6 @@ instance seeded in the same bundle (verified: `GET /fhir/ClinicalSnippet/snippet
   [init-bundle-env-template](../init-bundle-env-template/).
 - **Delivering the bundle to a pod** (image / ConfigMap / init container / URL):
   see the [init bundle docs](https://www.health-samurai.io/docs/aidbox/configuration/init-bundle).
-- **CI** (`.github/workflows/build-init-bundle.yml`) is illustrative — GitHub
-  only runs workflows at the repo root, so copy it there. It just builds the IG
-  and one bundle per environment and uploads `dist/`.
 
 `dist/` is generated (`.gitignore`d); commit `ig/`, `common/`, `dev/`, `qa/`,
 `prod/`, and the two build scripts.

--- a/aidbox-features/init-bundle-from-directories/build-ig.sh
+++ b/aidbox-features/init-bundle-from-directories/build-ig.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Pack the custom FHIR IG (ig/package/) into dist/custom-ig.tgz.
+#
+# A FHIR npm package is just a gzipped tarball rooted at `package/`, so plain tar
+# is enough. The init bundle installs it via $fhir-package-install (see
+# common/00_packages/install-fhir-packages.json).
+#
+# Usage: ./build-ig.sh [IG_SRC_DIR] [OUTPUT_DIR]   (defaults: ig, dist)
+
+set -euo pipefail
+
+IG_SRC="${1:-ig}"
+OUTPUT_DIR="${2:-dist}"
+TARBALL="$OUTPUT_DIR/custom-ig.tgz"
+
+if [ ! -f "$IG_SRC/package/package.json" ]; then
+  echo "error: '$IG_SRC/package/package.json' not found" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+# -C "$IG_SRC" so the archive root is `package/`, as FHIR npm packages require.
+tar -czf "$TARBALL" -C "$IG_SRC" package
+
+echo "Built $TARBALL from $IG_SRC/package"

--- a/aidbox-features/init-bundle-from-directories/build-init-bundle.sh
+++ b/aidbox-features/init-bundle-from-directories/build-init-bundle.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Build one environment's Aidbox init bundle = common/ + <env>/.
+#
+#   common/         config/metadata shared by every environment
+#   dev/ qa/ prod/  resources specific to that environment (seed data;
+#                   prod adds nothing, so its bundle is common only)
+#
+# Files are ordered by directory number (00_ first). A Parameters resource
+# becomes POST $fhir-package-install (bundle-relative url — NOT
+# /fhir/$fhir-package-install, which 404s as /fhir/fhir/...); everything else is
+# an idempotent PUT-by-id in a "batch" bundle. Per-env secrets are out of scope —
+# inject them at container start (see the init-bundle-env-template example).
+#
+# Usage: ./build-init-bundle.sh [ENV] [OUTPUT_FILE]   (defaults: dev, dist/init-bundle.json)
+# Requires: bash, jq.
+
+set -euo pipefail
+
+ENV_NAME="${1:-dev}"
+OUTPUT_FILE="${2:-dist/init-bundle.json}"
+
+if [ ! -d "$ENV_NAME" ] || [ "$ENV_NAME" = common ]; then
+  echo "error: '$ENV_NAME' is not an environment folder (dev|qa|prod)" >&2; exit 1
+fi
+
+# common/ (shared) + the environment's own folder, each sorted by dir number.
+files=()
+for root in common "$ENV_NAME"; do
+  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done < <(find "$root" -type f -name '*.json' | sort)
+done
+
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+jq -s '
+  def to_entry:
+    if .resourceType == "Parameters"
+    then { resource: ., request: { method: "POST", url: "$fhir-package-install" } }
+    else { resource: ., request: { method: "PUT", url: (.resourceType + "/" + .id) } }
+    end;
+
+  map(
+    if .resourceType == null then error("resource is missing resourceType")
+    elif .resourceType != "Parameters" and .id == null
+    then error("resource \(.resourceType) is missing id") else . end
+  )
+  | { resourceType: "Bundle", type: "batch", entry: map(to_entry) }
+' "${files[@]}" > "$OUTPUT_FILE"
+
+echo "Wrote $(jq '.entry | length' "$OUTPUT_FILE") entries (env: $ENV_NAME) to $OUTPUT_FILE"

--- a/aidbox-features/init-bundle-from-directories/build-init-bundle.sh
+++ b/aidbox-features/init-bundle-from-directories/build-init-bundle.sh
@@ -6,11 +6,15 @@
 #   dev/ qa/ prod/  resources specific to that environment (seed data;
 #                   prod adds nothing, so its bundle is common only)
 #
-# Files are ordered by directory number (00_ first). A Parameters resource
-# becomes POST $fhir-package-install (bundle-relative url — NOT
-# /fhir/$fhir-package-install, which 404s as /fhir/fhir/...); everything else is
-# an idempotent PUT-by-id in a "batch" bundle. Per-env secrets are out of scope —
-# inject them at container start (see the init-bundle-env-template example).
+# Files are ordered by directory number (00_ first). A bare resource file
+# becomes an idempotent PUT by resourceType/id; a file that carries its own
+# "request" (e.g. the $fhir-package-install operation) is used as a bundle entry
+# verbatim. Everything goes into one "batch" bundle. Per-env secrets are out of
+# scope — inject them at container start (see the init-bundle-env-template example).
+#
+# NOTE for operation entries: request.url is relative to the FHIR base —
+# "$fhir-package-install", NOT "/fhir/$fhir-package-install" (which 404s as
+# /fhir/fhir/...).
 #
 # Usage: ./build-init-bundle.sh [ENV] [OUTPUT_FILE]   (defaults: dev, dist/init-bundle.json)
 # Requires: bash, jq.
@@ -32,18 +36,17 @@ done
 
 mkdir -p "$(dirname "$OUTPUT_FILE")"
 jq -s '
-  def to_entry:
-    if .resourceType == "Parameters"
-    then { resource: ., request: { method: "POST", url: "$fhir-package-install" } }
-    else { resource: ., request: { method: "PUT", url: (.resourceType + "/" + .id) } }
-    end;
-
+  # A file is either a full bundle entry (has its own "request" — used as-is,
+  # e.g. an operation like $fhir-package-install) or a bare resource, which
+  # becomes an idempotent PUT by resourceType/id.
   map(
-    if .resourceType == null then error("resource is missing resourceType")
-    elif .resourceType != "Parameters" and .id == null
-    then error("resource \(.resourceType) is missing id") else . end
+    if has("request") then .
+    elif .resourceType == null then error("file has no request and no resourceType")
+    elif .id == null then error("resource \(.resourceType) has no id (needed for PUT)")
+    else { resource: ., request: { method: "PUT", url: (.resourceType + "/" + .id) } }
+    end
   )
-  | { resourceType: "Bundle", type: "batch", entry: map(to_entry) }
+  | { resourceType: "Bundle", type: "batch", entry: . }
 ' "${files[@]}" > "$OUTPUT_FILE"
 
 echo "Wrote $(jq '.entry | length' "$OUTPUT_FILE") entries (env: $ENV_NAME) to $OUTPUT_FILE"

--- a/aidbox-features/init-bundle-from-directories/common/00_packages/install-fhir-packages.json
+++ b/aidbox-features/init-bundle-from-directories/common/00_packages/install-fhir-packages.json
@@ -1,9 +1,9 @@
 {
-  "resourceType": "Parameters",
-  "parameter": [
-    {
-      "name": "package",
-      "valueString": "file:///tmp/ig/custom-ig.tgz"
-    }
-  ]
+  "request": { "method": "POST", "url": "$fhir-package-install" },
+  "resource": {
+    "resourceType": "Parameters",
+    "parameter": [
+      { "name": "package", "valueString": "file:///tmp/ig/custom-ig.tgz" }
+    ]
+  }
 }

--- a/aidbox-features/init-bundle-from-directories/common/00_packages/install-fhir-packages.json
+++ b/aidbox-features/init-bundle-from-directories/common/00_packages/install-fhir-packages.json
@@ -1,0 +1,9 @@
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "package",
+      "valueString": "file:///tmp/ig/custom-ig.tgz"
+    }
+  ]
+}

--- a/aidbox-features/init-bundle-from-directories/common/01_StructureDefinition/clinical-snippet.json
+++ b/aidbox-features/init-bundle-from-directories/common/01_StructureDefinition/clinical-snippet.json
@@ -1,0 +1,21 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "ClinicalSnippet",
+  "url": "http://example.org/fhir/StructureDefinition/ClinicalSnippet",
+  "name": "ClinicalSnippet",
+  "status": "active",
+  "kind": "resource",
+  "abstract": false,
+  "type": "ClinicalSnippet",
+  "derivation": "specialization",
+  "fhirVersion": "4.0.1",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/DomainResource",
+  "differential": {
+    "element": [
+      { "id": "ClinicalSnippet",          "path": "ClinicalSnippet",          "min": 0, "max": "*" },
+      { "id": "ClinicalSnippet.title",     "path": "ClinicalSnippet.title",    "min": 1, "max": "1", "type": [{ "code": "string" }] },
+      { "id": "ClinicalSnippet.category",  "path": "ClinicalSnippet.category", "min": 0, "max": "1", "type": [{ "code": "code" }] },
+      { "id": "ClinicalSnippet.body",      "path": "ClinicalSnippet.body",     "min": 1, "max": "1", "type": [{ "code": "markdown" }] }
+    ]
+  }
+}

--- a/aidbox-features/init-bundle-from-directories/common/02_App/myorg-reporting.json
+++ b/aidbox-features/init-bundle-from-directories/common/02_App/myorg-reporting.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "App",
+  "id": "myorg.reporting",
+  "apiVersion": 1,
+  "type": "app",
+  "endpoint": {
+    "type": "http-rpc",
+    "url": "https://reporting.internal:8888",
+    "secret": "reporting-app-secret"
+  }
+}

--- a/aidbox-features/init-bundle-from-directories/common/02_App/myorg-reporting.json
+++ b/aidbox-features/init-bundle-from-directories/common/02_App/myorg-reporting.json
@@ -7,5 +7,15 @@
     "type": "http-rpc",
     "url": "https://reporting.internal:8888",
     "secret": "reporting-app-secret"
+  },
+  "operations": {
+    "generate-report": {
+      "method": "POST",
+      "path": ["reporting", "generate"]
+    },
+    "get-report": {
+      "method": "GET",
+      "path": ["reporting", "report", { "name": "reportId" }]
+    }
   }
 }

--- a/aidbox-features/init-bundle-from-directories/common/03_Client/data-analyst.json
+++ b/aidbox-features/init-bundle-from-directories/common/03_Client/data-analyst.json
@@ -1,0 +1,8 @@
+{
+  "resourceType": "Client",
+  "id": "data-analyst",
+  "secret": "data-analyst-secret",
+  "grant_types": [
+    "basic"
+  ]
+}

--- a/aidbox-features/init-bundle-from-directories/common/03_Client/my-app.json
+++ b/aidbox-features/init-bundle-from-directories/common/03_Client/my-app.json
@@ -1,0 +1,8 @@
+{
+  "resourceType": "Client",
+  "id": "my-app",
+  "secret": "my-app-secret",
+  "grant_types": [
+    "basic"
+  ]
+}

--- a/aidbox-features/init-bundle-from-directories/common/04_AccessPolicy/as-data-analyst-read-only.json
+++ b/aidbox-features/init-bundle-from-directories/common/04_AccessPolicy/as-data-analyst-read-only.json
@@ -1,0 +1,13 @@
+{
+  "resourceType": "AccessPolicy",
+  "id": "as-data-analyst-read-only",
+  "engine": "matcho",
+  "link": [
+    {
+      "reference": "Client/data-analyst"
+    }
+  ],
+  "matcho": {
+    "request-method": "get"
+  }
+}

--- a/aidbox-features/init-bundle-from-directories/common/04_AccessPolicy/as-my-app-crud-patients.json
+++ b/aidbox-features/init-bundle-from-directories/common/04_AccessPolicy/as-my-app-crud-patients.json
@@ -1,0 +1,18 @@
+{
+  "resourceType": "AccessPolicy",
+  "id": "as-my-app-crud-patients",
+  "engine": "matcho",
+  "link": [
+    {
+      "reference": "Client/my-app"
+    }
+  ],
+  "matcho": {
+    "params": {
+      "resource/type": "Patient"
+    },
+    "request-method": {
+      "$enum": ["get", "post", "put", "patch"]
+    }
+  }
+}

--- a/aidbox-features/init-bundle-from-directories/dev/05_Organization/org-acme.json
+++ b/aidbox-features/init-bundle-from-directories/dev/05_Organization/org-acme.json
@@ -1,0 +1,7 @@
+{
+  "resourceType": "Organization",
+  "id": "org-acme",
+  "identifier": [{ "system": "http://example.org/org", "value": "acme" }],
+  "active": true,
+  "name": "Acme Health"
+}

--- a/aidbox-features/init-bundle-from-directories/dev/06_Practitioner/pr-house.json
+++ b/aidbox-features/init-bundle-from-directories/dev/06_Practitioner/pr-house.json
@@ -1,0 +1,6 @@
+{
+  "resourceType": "Practitioner",
+  "id": "pr-house",
+  "identifier": [{ "system": "http://example.org/npi", "value": "1234567890" }],
+  "name": [{ "use": "official", "family": "House", "given": ["Gregory"], "prefix": ["Dr"] }]
+}

--- a/aidbox-features/init-bundle-from-directories/dev/07_Patient/pt-demo-1.json
+++ b/aidbox-features/init-bundle-from-directories/dev/07_Patient/pt-demo-1.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Patient",
+  "id": "pt-demo-1",
+  "meta": { "profile": ["http://example.org/fhir/StructureDefinition/myorg-patient"] },
+  "identifier": [{ "system": "http://example.org/mrn", "value": "MRN-001" }],
+  "name": [{ "use": "official", "family": "Demo", "given": ["Dana"] }],
+  "gender": "female",
+  "birthDate": "1990-05-01",
+  "managingOrganization": { "reference": "Organization/org-acme" },
+  "generalPractitioner": [{ "reference": "Practitioner/pr-house" }]
+}

--- a/aidbox-features/init-bundle-from-directories/dev/07_Patient/pt-demo-2.json
+++ b/aidbox-features/init-bundle-from-directories/dev/07_Patient/pt-demo-2.json
@@ -1,0 +1,9 @@
+{
+  "resourceType": "Patient",
+  "id": "pt-demo-2",
+  "identifier": [{ "system": "http://example.org/mrn", "value": "MRN-002" }],
+  "name": [{ "use": "official", "family": "Demo", "given": ["Sam"] }],
+  "gender": "male",
+  "birthDate": "1985-11-20",
+  "managingOrganization": { "reference": "Organization/org-acme" }
+}

--- a/aidbox-features/init-bundle-from-directories/dev/08_Observation/obs-demo-1.json
+++ b/aidbox-features/init-bundle-from-directories/dev/08_Observation/obs-demo-1.json
@@ -1,0 +1,8 @@
+{
+  "resourceType": "Observation",
+  "id": "obs-demo-1",
+  "status": "final",
+  "code": { "coding": [{ "system": "http://loinc.org", "code": "29463-7", "display": "Body weight" }] },
+  "subject": { "reference": "Patient/pt-demo-1" },
+  "valueQuantity": { "value": 65, "unit": "kg", "system": "http://unitsofmeasure.org", "code": "kg" }
+}

--- a/aidbox-features/init-bundle-from-directories/dev/09_ClinicalSnippet/snippet-welcome.json
+++ b/aidbox-features/init-bundle-from-directories/dev/09_ClinicalSnippet/snippet-welcome.json
@@ -1,0 +1,7 @@
+{
+  "resourceType": "ClinicalSnippet",
+  "id": "snippet-welcome",
+  "title": "Welcome",
+  "category": "greeting",
+  "body": "Hello, and welcome to your visit today."
+}

--- a/aidbox-features/init-bundle-from-directories/docker-compose.yaml
+++ b/aidbox-features/init-bundle-from-directories/docker-compose.yaml
@@ -1,0 +1,64 @@
+volumes:
+  postgres_data: {}
+services:
+  postgres:
+    image: docker.io/library/postgres:18
+    volumes:
+    - postgres_data:/var/lib/postgresql/18/docker:delegated
+    command:
+    - postgres
+    - -c
+    - shared_preload_libraries=pg_stat_statements
+    environment:
+      POSTGRES_USER: aidbox
+      POSTGRES_PORT: '5432'
+      POSTGRES_DB: aidbox
+      POSTGRES_PASSWORD: aidbox
+  aidbox:
+    image: docker.io/healthsamurai/aidboxone:edge
+    pull_policy: always
+    depends_on:
+    - postgres
+    ports:
+    - 8080:8080
+    # Run ./build-ig.sh and ./build-init-bundle.sh before `docker compose up` —
+    # these files must exist to mount.
+    volumes:
+    - ./dist/init-bundle.json:/tmp/init-bundle.json:ro
+    - ./dist/custom-ig.tgz:/tmp/ig/custom-ig.tgz:ro
+    environment:
+      BOX_INIT_BUNDLE: file:///tmp/init-bundle.json
+      BOX_ADMIN_PASSWORD: t_LRDXTuel
+      # Published IGs (name#ver:name#ver). Loaded ONLY on first startup (fresh DB).
+      BOX_BOOTSTRAP_FHIR_PACKAGES: hl7.fhir.r4.core#4.0.1:hl7.fhir.us.core#6.1.0
+      BOX_COMPATIBILITY_VALIDATION_JSON__SCHEMA_REGEX: '#{:fhir-datetime}'
+      BOX_DB_DATABASE: aidbox
+      BOX_DB_HOST: postgres
+      BOX_DB_PASSWORD: aidbox
+      BOX_DB_PORT: '5432'
+      BOX_DB_USER: aidbox
+      BOX_FHIR_BUNDLE_EXECUTION_VALIDATION_MODE: limited
+      BOX_FHIR_COMPLIANT_MODE: 'true'
+      BOX_FHIR_CORRECT_AIDBOX_FORMAT: 'true'
+      BOX_FHIR_CREATEDAT_URL: https://aidbox.app/ex/createdAt
+      BOX_FHIR_SCHEMA_VALIDATION: 'true'
+      BOX_FHIR_SEARCH_AUTHORIZE_INLINE_REQUESTS: 'true'
+      BOX_FHIR_SEARCH_CHAIN_SUBSELECT: 'true'
+      BOX_FHIR_SEARCH_COMPARISONS: 'true'
+      BOX_FHIR_TERMINOLOGY_ENGINE: hybrid
+      BOX_FHIR_TERMINOLOGY_ENGINE_HYBRID_EXTERNAL_TX_SERVER: https://tx5.health-samurai.io/fhir
+      BOX_FHIR_TERMINOLOGY_SERVICE_BASE_URL: https://tx5.health-samurai.io/fhir
+      BOX_MODULE_SDC_STRICT_ACCESS_CONTROL: 'true'
+      BOX_ROOT_CLIENT_SECRET: L_N3G5oUT0
+      BOX_SEARCH_INCLUDE_CONFORMANT: 'true'
+      BOX_SECURITY_AUDIT_LOG_ENABLED: 'true'
+      BOX_SECURITY_DEV_MODE: 'true'
+      BOX_SETTINGS_MODE: read-write
+      BOX_WEB_BASE_URL: http://localhost:8080
+      BOX_WEB_PORT: 8080
+    healthcheck:
+      test: curl -f http://localhost:8080/health || exit 1
+      interval: 5s
+      timeout: 5s
+      retries: 90
+      start_period: 30s

--- a/aidbox-features/init-bundle-from-directories/ig/package/.index.json
+++ b/aidbox-features/init-bundle-from-directories/ig/package/.index.json
@@ -1,0 +1,14 @@
+{
+  "index-version": 2,
+  "files": [
+    {
+      "filename": "myorg-patient.json",
+      "resourceType": "StructureDefinition",
+      "id": "myorg-patient",
+      "url": "http://example.org/fhir/StructureDefinition/myorg-patient",
+      "version": "1.0.0",
+      "kind": "resource",
+      "type": "Patient"
+    }
+  ]
+}

--- a/aidbox-features/init-bundle-from-directories/ig/package/myorg-patient.json
+++ b/aidbox-features/init-bundle-from-directories/ig/package/myorg-patient.json
@@ -1,0 +1,25 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "myorg-patient",
+  "url": "http://example.org/fhir/StructureDefinition/myorg-patient",
+  "version": "1.0.0",
+  "name": "MyOrgPatient",
+  "title": "MyOrg Patient",
+  "status": "active",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Patient",
+  "baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Patient.birthDate",
+        "path": "Patient.birthDate",
+        "min": 1,
+        "mustSupport": true
+      }
+    ]
+  }
+}

--- a/aidbox-features/init-bundle-from-directories/ig/package/package.json
+++ b/aidbox-features/init-bundle-from-directories/ig/package/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "myorg.example.ig",
+  "version": "1.0.0",
+  "description": "A minimal custom FHIR IG for the init-bundle example",
+  "author": "Health Samurai Examples",
+  "dependencies": {
+    "hl7.fhir.r4.core": "4.0.1",
+    "hl7.fhir.us.core": "6.1.0"
+  }
+}

--- a/aidbox-features/init-bundle-from-directories/prod/03_Client/ops-monitor.json
+++ b/aidbox-features/init-bundle-from-directories/prod/03_Client/ops-monitor.json
@@ -1,0 +1,6 @@
+{
+  "resourceType": "Client",
+  "id": "ops-monitor",
+  "secret": "ops-monitor-secret",
+  "grant_types": ["basic"]
+}

--- a/aidbox-features/init-bundle-from-directories/qa/05_Organization/org-acme.json
+++ b/aidbox-features/init-bundle-from-directories/qa/05_Organization/org-acme.json
@@ -1,0 +1,7 @@
+{
+  "resourceType": "Organization",
+  "id": "org-acme",
+  "identifier": [{ "system": "http://example.org/org", "value": "acme" }],
+  "active": true,
+  "name": "Acme Health"
+}

--- a/aidbox-features/init-bundle-from-directories/qa/07_Patient/pt-demo-2.json
+++ b/aidbox-features/init-bundle-from-directories/qa/07_Patient/pt-demo-2.json
@@ -1,0 +1,9 @@
+{
+  "resourceType": "Patient",
+  "id": "pt-demo-2",
+  "identifier": [{ "system": "http://example.org/mrn", "value": "MRN-002" }],
+  "name": [{ "use": "official", "family": "Demo", "given": ["Sam"] }],
+  "gender": "male",
+  "birthDate": "1985-11-20",
+  "managingOrganization": { "reference": "Organization/org-acme" }
+}


### PR DESCRIPTION
A new `aidbox-features` example: compile a directory of per-resource-type JSON files into **one Aidbox init bundle** (config + seed data) that loads at startup — instead of a hand-ordered script that POSTs resources one by one after boot.

## What it shows
- **`common/`** (config, every environment) **+ `dev/` `qa/` `prod/`** (per-env resources). A bundle for an environment is `common/` + that env's folder, so the tree shows exactly what each env gets (`dev` = common + dev, `prod` = common only).
- **Custom FHIR IG built from source** (`ig/`) and installed from a local `.tgz` via `$fhir-package-install`; its `MyOrgPatient` profile **derives from us.core**.
- **Published us.core** loaded via `BOX_BOOTSTRAP_FHIR_PACKAGES`.
- **Custom resource type** (`ClinicalSnippet`) registered **and** seeded in the same bundle.
- Idempotent `PUT`-by-id, `batch` bundle, ordering by directory number.

Two small scripts (`build-ig.sh`, `build-init-bundle.sh`) + `docker-compose.yaml`. Requires only `jq`. Verified end-to-end against a running Aidbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)