### PR TITLE
shared-assessment-link: time-bounded, field-redacted assessment sharing over SHL

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A collection of examples on top of Aidbox FHIR platform
 - [GraphQL Federation](aidbox-integrations/apollo-graphql-federation/)
 - [FHIR R5 Topic-Based Subscriptions](aidbox-integrations/r5-subscriptions/)
 - [SMART Health Links for eligibility results](aidbox-integrations/smart-health-link/)
+- [SMART Health Links: time-bounded assessment sharing between providers](aidbox-integrations/shared-assessment-link/)
 
 ## Aidbox Features
 

--- a/aidbox-integrations/shared-assessment-link/.dockerignore
+++ b/aidbox-integrations/shared-assessment-link/.dockerignore
@@ -1,0 +1,27 @@
+# Dependencies
+node_modules
+npm-debug.log
+
+# Source control
+.git
+.gitignore
+
+# Environment files (use env vars or mounted configs instead)
+.env*
+!.env.example
+
+# Development files
+.vscode
+.DS_Store
+*.log
+temp
+
+# Documentation
+README.md
+docs
+adr
+
+# Docker files (don't include in image)
+Dockerfile*
+docker-compose*.yaml
+.dockerignore

--- a/aidbox-integrations/shared-assessment-link/.env.example
+++ b/aidbox-integrations/shared-assessment-link/.env.example
@@ -1,0 +1,30 @@
+# Aidbox Configuration
+# Bare host — the Aidbox client appends /fhir itself.
+AIDBOX_BASE_URL=http://localhost:8080
+AIDBOX_CLIENT_ID=share-client
+AIDBOX_CLIENT_SECRET=secret
+
+# SMART Health Link Configuration
+# Public base URL of THIS app's SHL endpoints, as reachable by the recipient's
+# browser. The manifest URL embedded in the shlink: is built from this.
+SHL_PUBLIC_BASE_URL=http://localhost:8080/share-app
+# SHL viewer prepended to the shlink: (must end with #). Points at the in-app
+# viewer so minted links open it with the SHL prefilled. Leave empty for a bare shlink:.
+SHL_VIEWER_URL=http://localhost:3100/#
+
+# The organization this deployment shares AS (Provider A). Assessments are scoped
+# to those it authored, so a share never exposes another org's data.
+SHARE_SOURCE_ORGANIZATION=Organization/provider-a
+# Default length of a sharing window, in days, when no end date is supplied
+SHARE_DEFAULT_WINDOW_DAYS=30
+
+# SHL protocol policy
+# Lifetime incorrect-passcode attempts before a P-flag share locks
+SHL_PASSCODE_MAX_ATTEMPTS=5
+# Lifetime of a manifest-issued `location` URL, in seconds (spec allows <= 3600)
+SHL_FILE_TOKEN_TTL_SECONDS=60
+# Minimum seconds between manifest polls for one share before returning 429
+SHL_MANIFEST_MIN_INTERVAL_SECONDS=1
+
+# Server Configuration
+PORT=3000

--- a/aidbox-integrations/shared-assessment-link/.gitignore
+++ b/aidbox-integrations/shared-assessment-link/.gitignore
@@ -1,0 +1,20 @@
+# Dependencies
+node_modules/
+
+# Logs
+logs/
+*.log
+
+# Environment variables
+.env
+.env.local
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/aidbox-integrations/shared-assessment-link/CLAUDE.MD
+++ b/aidbox-integrations/shared-assessment-link/CLAUDE.MD
@@ -1,0 +1,65 @@
+# Project Overview
+
+This project implements **time-bounded, field-redacted assessment sharing between provider organizations** in TypeScript on the [Bun](https://bun.sh) runtime, integrated with Aidbox, using **SMART Health Links (SHL)** as the transport. Provider Organization A records GAD-7 assessments for a patient and grants Provider Organization B a link that resolves only inside a date window, and only to the questionnaire items A chose to share. The implementation should be minimal and focused on core functionality.
+
+## The central design decision
+
+Unlike a snapshot-style SHL, **nothing is encrypted at mint time**. An `AssessmentShare` stores only a *policy* (patient, questionnaire, window, hidden items). Every manifest poll re-queries live assessments, re-applies the redaction, and encrypts the result fresh. Three requirements fall out of that one choice:
+
+- **live** — assessments A completes after minting appear on B's next poll, with no re-minting;
+- **closable** — the window is evaluated at read time, so the end date closes access on its own and an early revoke is immediate; there is no pre-encrypted copy to claw back;
+- **retroactively redactable** — tightening `hiddenItems` applies to a link already sent.
+
+The seam is `ContentProvider` in `src/services/share-service.ts`: the protocol engine knows nothing about assessments and asks for bytes on each read.
+
+## Architecture
+
+- **FHIR Server**: Aidbox with custom operation routing (Aidbox Apps) and an `AssessmentShare` custom resource
+- **Application**: Bun + TypeScript service (no build step — Bun runs TS directly)
+- **Integration**: Aidbox proxies App operations to the service; the service calls back into Aidbox via the FHIR API
+- **Content**: a FHIR searchset `Bundle` of redacted `QuestionnaireResponse`s, encrypted as a JWE (`alg: dir`, `enc: A256GCM`)
+- **UI**: a browser page (`src/app.html`, served at `GET /`) with four roles — record a GAD-7, share it, manage shares, open a link. The fourth is a real SHL receiver that decrypts client-side with WebCrypto; `SHL_VIEWER_URL` is wired to it so minted links open it prefilled.
+- **Form rendering**: the GAD-7 intake form is a React island (`src/forms/intake.tsx`) rendered by [`@formbox/renderer`](https://github.com/HealthSamurai/formbox-renderer) with `@formbox/hs-theme` — the same renderer [HealthSamurai/phr](https://github.com/HealthSamurai/phr) uses. `Bun.build()` compiles it at server startup, so there is still no separate build command; the other three tabs remain plain no-build HTML.
+- **Palette**: light, drawn from `@formbox/hs-theme`'s slate/blue ramp so the rendered form belongs to the page rather than sitting in its own white box. Defined as tokens on `:root` in `src/app.html`; components style through the tokens, so the palette is changed in one place. Colors carry meaning and are not interchangeable: `--accent` (blue) marks what happens *in the browser* (decryption, the key), `--server` (violet) what the backend does, `--locked` (amber) a withheld or pending thing, `--danger` a closed one. All pairs pass WCAG AA for normal text — the previous mint accent scored ~1.5:1 on white, which is why that role moved to blue rather than being kept.
+
+## Key Resources
+
+### Specification
+- **SMART Health Links IG**: https://hl7.org/fhir/uv/smart-health-cards-and-links/STU1/links-specification.html
+- **Flags used**: `L` (long-term). Optional: `P` (passcode). Not used: `U` (direct file).
+- A share is never `finalized` — it is `can-change` while open (contents evolve), then `no-longer-valid`.
+
+### Aidbox Integration
+- **Init Bundle**: `init-bundle/bundle.json` — Client, AccessPolicy, the `AssessmentShare` StructureDefinition, the `share-app` App with four operations, the GAD-7 `Questionnaire` + terminology, two `Organization`s and a demo `Patient`.
+- **App Resource**: routes `$create`, `$revoke`, `manifest/{shareId}`, and `file/{fileId}` to the Bun service. Create and revoke are authenticated; manifest and file are public via an inline `allow` policy. See [Aidbox Apps](https://www.health-samurai.io/docs/aidbox/app-development/aidbox-sdk/apps).
+- **Custom Resource**: `AssessmentShare` persists one sharing grant (parties, window, hidden items, passcode state, file tokens, access log).
+
+## Development Commands
+
+```bash
+bun install        # install dependencies
+bun run dev        # watch mode (bun --watch)
+bun run start      # run once
+bunx tsc --noEmit  # type-check
+docker compose up --build   # full stack (Aidbox + app)
+```
+
+The app is published on **port 3100** (Aidbox on 8080) to stay clear of the common 3000 default.
+
+## Project Scope
+
+- **Backend + a self-contained demo UI**: the focus is the backend sharing flow; `src/app.html` is a single-file browser app (no build, no framework) included to exercise it end to end.
+- **Core functionality**: capture GAD-7 responses, create a share (window + item redaction), resolve the manifest against live data, decrypt client-side, revoke early, and audit reads.
+- **Runtime**: Bun (native `Bun.serve` HTTP, auto-loaded `.env`, direct TypeScript execution — no `tsc`/`ts-node`/`nodemon`).
+- **FHIR access**: the official `@health-samurai/aidbox-client` (Basic auth via `BasicAuthProvider`, typed `AidboxClient` returning a `Result`).
+
+## Notable implementation details
+
+- **Score leakage**: a GAD-7 total is the sum of its items, so publishing it next to a hidden item leaks that answer. `redactResponse` recomputes the score from *visible* items whenever anything scored was hidden, and `shareScore: false` drops it entirely. See `src/services/redaction.ts`.
+- **Masked, not missing**: a hidden item keeps its `linkId` and text but loses its answer and gains a `masked` data-absent-reason, so a receiving clinician can distinguish "withheld" from "unanswered".
+- **File tokens freeze their ciphertext**: because content is rebuilt per read, a `location` URL must serve the exact bytes its manifest advertised — so the JWE is stored on the token, not regenerated.
+- **`QuestionnaireResponse.author`** (not `.source`) scopes a share to the sharing organization's own assessments. FHIR restricts `source` to a *person* (`Patient | Practitioner | PractitionerRole | RelatedPerson`) and Aidbox's schema validation rejects an `Organization` there; `author` admits one, and the spec states that responses "authored by other collections of people must use Organization". It also has a stock search parameter, so the scoping is pushed into the Aidbox query rather than filtered in memory.
+- **FHIR rejects empty arrays.** `hiddenItems` and `fileTokens` are omitted rather than written as `[]` — worth knowing, since the natural `?? []` default makes every write of an unhidden share fail validation.
+- **The GAD-7 uses inline `answerOption`, not `answerValueSet`.** Aidbox's hybrid terminology engine returned an empty expansion for the stored ValueSets (expanding the same `compose` inline worked, so the concept-level filter wasn't honored), and `ValueSet/$expand` requires auth the browser doesn't have. Inline options sidestep both: the renderer needs no terminology round trip and no credentials. The `CodeSystem`/`ValueSet` resources remain in the init bundle as the terminology of record.
+- **The form is the single source of truth for the instrument.** `/demo/intake-form` serves `Questionnaire/gad7` straight from Aidbox, and the share tab's redaction checkboxes are built from the same resource — so adding an item to the instrument surfaces in both the form and the hide-list without a code change. `GAD7_ITEMS` in `types/gad7.ts` now only backs scoring and the API/seed path.
+- **`submitGad7` never trusts the client.** It accepts either the renderer's `item[]` or coded answers, then rebuilds items from `GAD7_ITEMS` and stamps `author`, `status` and the score server-side. Unknown linkIds and codes are dropped, so a browser cannot widen the instrument or assert its own total.

--- a/aidbox-integrations/shared-assessment-link/Dockerfile
+++ b/aidbox-integrations/shared-assessment-link/Dockerfile
@@ -1,0 +1,23 @@
+# Use the official Bun image
+FROM oven/bun:1-alpine
+
+# Install curl for the container healthcheck
+RUN apk add --no-cache curl
+
+WORKDIR /app
+
+# Install dependencies first (better layer caching)
+COPY package.json bun.lock* ./
+RUN bun install
+
+# Copy source
+COPY . .
+
+# Run as the non-root user that the Bun image ships with
+USER bun
+
+# Expose port
+EXPOSE 3000
+
+# Bun runs TypeScript directly — no build step
+CMD ["bun", "src/server.ts"]

--- a/aidbox-integrations/shared-assessment-link/README.md
+++ b/aidbox-integrations/shared-assessment-link/README.md
@@ -1,0 +1,541 @@
+---
+features: [SMART Health Links, Time-bounded sharing, Field-level redaction, JWE encryption, Custom resources, Aidbox Apps]
+languages: [TypeScript]
+runtimes: [Bun]
+---
+# SMART Health Links: Time-Bounded Assessment Sharing
+
+A small TypeScript ([Bun](https://bun.sh)) implementation of [SMART Health Links (SHL)](https://hl7.org/fhir/uv/smart-health-cards-and-links/STU1/links-specification.html) on Aidbox. One provider organization shares a patient's GAD-7 assessment history with another organization — for a fixed window, with chosen questions held back — and can close the sharing early.
+
+> **There are two SHL examples in this repo.** [`smart-health-link`](../smart-health-link/) shares a **snapshot**: it encrypts one finished result (an eligibility response) at mint time, and is the shorter read if you want the bare protocol. This one shares a **live, policy-driven view** — content is rebuilt and re-redacted on every read, which is what makes a time window, automatic expiry, and immediate revocation work. Same protocol, opposite ends of the "fixed content vs. evolving content" tradeoff.
+
+## Use case
+
+A behavioral-health practice has been seeing a patient for months and has a run of GAD-7 assessments on file. They refer the patient to a psychiatry group, a separate organization with its own records system and no access to theirs.
+
+From the referring practice's side:
+
+1. **They record assessments** as they normally would — each GAD-7 becomes a FHIR `QuestionnaireResponse`.
+2. **They grant access** to the receiving organization: this patient, these dates, and a tick-box for any question that should stay private.
+3. **They get a link** to hand over. Nothing else to coordinate.
+4. **They can watch and close it.** They see when the recipient actually read it, and can end the sharing before the date if the referral falls through.
+
+From the receiving organization's side: they open the link and see the history, with withheld questions marked as withheld rather than silently missing. Assessments the referring practice completes later show up the next time they open it. On the end date the link stops working.
+
+**What makes that work: nothing is encrypted when the link is created.** The share stores only a *policy* — which patient, which window, which items. Every time the recipient opens the link, the server re-queries the live assessments, re-applies the redaction, and encrypts the result fresh. Three properties follow from that single choice:
+
+| Requirement | Why it holds |
+|---|---|
+| New assessments appear automatically | Each read re-runs the query, so anything added since is simply included |
+| The end date closes access on its own | The window is checked at read time — no scheduled job, nothing to clean up |
+| An early close takes effect at once | There is no pre-encrypted copy sitting on the server to claw back |
+| Tightening what's shared applies retroactively | Redaction runs on every read, so a link already sent honors the new policy |
+
+### Why this pattern, and not a fax
+
+SMART Health Links exist because the alternative is the patient re-entering their history on paper. That is the whole premise of **[Kill the Clipboard](https://killtheclipboard.com/)** — *"Stop filling out the same forms. Share your records from your phone."* — which asks patients to carry their records as a QR code and hand that over at intake instead of a pen.
+
+The same effort from the industry side is the [CMS Health Tech Ecosystem pledge](https://www.cms.gov/health-tech-ecosystem), under which ~60 health systems, EHR vendors and technology companies committed in 2025 to *accepting* that data — specifically via QR codes and SMART Health Cards / Links carrying FHIR. Also worth a look: [Leavitt Partners' Kill the Clipboard initiative](https://leavittpartners.com/kill-the-clipboard/) (industry, CMS-aligned but separate) and [`kill-the-clipboard`](https://github.com/vintasoftware/kill-the-clipboard), an open-source TypeScript implementation of both specs.
+
+Those are all about the **patient** carrying the link. This example is the other half of the same picture: the identical `shlink:` mechanism, minted by one organization for another, with a time limit and fields held back. If a clinic can accept a QR code from a patient, it can accept one from a referring practice — and the receiving end of this demo is the same code either way.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    A(["Provider A<br/><small>records + shares</small>"])
+    B(["Provider B<br/><small>receives the link</small>"])
+    AB["Aidbox<br/><small>FHIR server · routes operations,<br/>stores shares + responses</small>"]
+    S["Share App<br/><small>Bun backend · SHL protocol,<br/>window + redaction</small>"]
+
+    A ==>|"record GAD-7 / create share"| AB
+    B <==>|"manifest / file<br/><small>public, no auth</small>"| AB
+    AB ==>|"proxies operations"| S
+    S -.->|"reads live assessments,<br/>stores the share"| AB
+
+    classDef actor fill:#f3effc,stroke:#6b46c1,stroke-width:1px,color:#3f2a75
+    classDef svc fill:#ffffff,stroke:#94a3b8,stroke-width:1px,color:#1a202c
+    classDef app fill:#ebf4fb,stroke:#2b6cb0,stroke-width:1px,color:#12395e
+    class A,B actor
+    class AB svc
+    class S app
+```
+
+**Components:**
+- **FHIR Server**: Aidbox with [custom operation routing](https://www.health-samurai.io/docs/aidbox/app-development/aidbox-sdk/apps) and an `AssessmentShare` [custom resource](https://www.health-samurai.io/docs/aidbox/tutorials/artifact-registry-tutorials/custom-resources).
+- **Application**: Bun/TypeScript service implementing share creation, revocation, and the SHL manifest and file operations.
+
+**Output:** the content behind the link is a FHIR searchset `Bundle` of redacted `QuestionnaireResponse`s, encrypted as a JWE (`alg: dir`, `enc: A256GCM`) under the SHL key.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    actor A as Provider A
+    participant AB as Aidbox
+    participant S as Share App
+    actor B as Provider B
+
+    A->>AB: record a GAD-7 (QuestionnaireResponse)
+    A->>AB: POST $create (patient, window, hidden items)
+    AB->>S: Aidbox routes the call
+    S->>AB: store the AssessmentShare (policy only — no ciphertext)
+    S-->>A: shlink: + key
+    A-->>B: hand over the link (passcode separately, if set)
+
+    rect rgb(253, 246, 236)
+    Note over B,S: every read rebuilds the content
+    B->>AB: POST manifest (no auth)
+    AB->>S: Aidbox routes the call
+    S->>AB: query live assessments for this patient
+    S->>S: strip hidden items, gate the score, encrypt
+    S-->>B: can-change + the encrypted bundle
+    end
+    Note over B: decrypt locally,<br/>key from the link
+
+    A->>AB: record another GAD-7
+    B->>AB: POST manifest again
+    S-->>B: now includes the new assessment
+
+    A->>AB: POST $revoke (or the end date passes)
+    B->>AB: POST manifest
+    S-->>B: no-longer-valid
+```
+
+## Where the work could live instead
+
+This example puts the query and the field filtering in the app. That is one of four reasonable splits between the FHIR server and the SHL app, and the choice is not obvious — it trades enforcement strength against how much you have to model up front. The diagrams below are the alternatives, roughly in order of how much responsibility moves into Aidbox.
+
+Common to all four: the app always owns the SHL protocol itself (minting the `shlink:`, the manifest lifecycle, the passcode, the file tokens, JWE encryption). What moves is **who decides what the recipient may see**.
+
+The diagrams share a vocabulary, so the same shape means the same thing in each: **white** boxes are data at rest, **blue** are steps the app runs, and the **amber, heavier-bordered** box is where the withholding is actually enforced. Watching that amber box move from the app into Aidbox across the four diagrams *is* the comparison.
+
+### 1. App queries and filters — what this repo does
+
+```mermaid
+flowchart LR
+    subgraph AB["&nbsp;Aidbox&nbsp;"]
+        QR["QuestionnaireResponse<br/><small>stored as authored</small>"]
+        SH["AssessmentShare<br/><small>the sharing policy</small>"]
+    end
+    subgraph APP["&nbsp;SHL App&nbsp;"]
+        Q["query<br/><small>patient + author<br/>+ questionnaire</small>"]
+        R["strip hidden items<br/>recompute the score"]
+        E["encrypt<br/><small>JWE</small>"]
+    end
+    B(["Provider B"])
+
+    QR ==>|"full responses"| Q
+    SH -.->|"policy"| Q
+    Q ==> R ==> E ==> B
+
+    classDef store fill:#ffffff,stroke:#94a3b8,stroke-width:1px,color:#1a202c
+    classDef op fill:#ebf4fb,stroke:#2b6cb0,stroke-width:1px,color:#12395e
+    classDef guard fill:#fdf6ec,stroke:#b45309,stroke-width:2px,color:#7c3d06
+    classDef out fill:#f3effc,stroke:#6b46c1,stroke-width:1px,color:#3f2a75
+    classDef zone fill:#f7fafc,stroke:#cbd5e0,stroke-width:1px,color:#5a6b82
+    class QR,SH store
+    class Q,E op
+    class R guard
+    class B out
+    class AB,APP zone
+```
+
+The server is a plain store; every decision is app code. **Cheapest to build and the easiest to reason about** — the redaction rules, including the score-leak fix, are a single readable function. The cost is that the app reads unredacted data and is the only thing standing between it and the recipient: a bug in `redactResponse` is a disclosure. Filtering also can't be reused by any other client.
+
+### 2. Server extracts discrete resources, the app shares those
+
+```mermaid
+flowchart LR
+    subgraph AB["&nbsp;Aidbox&nbsp;"]
+        QR["QuestionnaireResponse"]
+        EX["$extract"]
+        OBS["Observation<br/>Condition<br/><small>discrete, coded</small>"]
+        QR ==> EX ==> OBS
+    end
+    subgraph APP["&nbsp;SHL App&nbsp;"]
+        Q["query<br/><small>by code + subject</small>"]
+        E["encrypt<br/><small>JWE</small>"]
+    end
+    B(["Provider B"])
+
+    OBS ==> Q ==> E ==> B
+
+    classDef store fill:#ffffff,stroke:#94a3b8,stroke-width:1px,color:#1a202c
+    classDef op fill:#ebf4fb,stroke:#2b6cb0,stroke-width:1px,color:#12395e
+    classDef guard fill:#fdf6ec,stroke:#b45309,stroke-width:2px,color:#7c3d06
+    classDef out fill:#f3effc,stroke:#6b46c1,stroke-width:1px,color:#3f2a75
+    classDef zone fill:#f7fafc,stroke:#cbd5e0,stroke-width:1px,color:#5a6b82
+    class QR,OBS store
+    class Q,E op
+    class EX guard
+    class B out
+    class AB,APP zone
+```
+
+Aidbox's [`$extract`](https://www.health-samurai.io/docs/aidbox/reference/aidbox-forms-reference/fhir-sdc-api) (Forms module; Observation-based and Definition-based extraction) turns a response into discrete resources. Sharing those instead means the recipient gets data that **drops straight into their chart** rather than a form they must read — far more useful clinically, and the natural fit if they want to trend a score alongside their own observations.
+
+Redaction changes character, though: the unit is no longer a `linkId` but a resource, so you select by code instead of item. Two traps come with it. Extracted resources can **reconstitute what you withheld** — hide an item but share the `Observation` derived from it and the answer walks out the back door; suppress the score but share a `Condition` of "severe anxiety" and the band leaks it. And to hide "everything derived from item 4" you need provenance recorded at extraction time (`itemExtractionContext`, or a `Provenance`/`derivedFrom` link). Without that, per-item redaction here is unenforceable.
+
+### 3. Prepare the Bundle in advance and store it
+
+```mermaid
+flowchart LR
+    subgraph ONCE["&nbsp;at share time · once&nbsp;"]
+        QR["QuestionnaireResponse<br/><small>in Aidbox</small>"]
+        P["build + redact"]
+        BD["Bundle<br/><small>redacted, stored<br/>in Aidbox</small>"]
+        QR ==> P ==> BD
+    end
+    subgraph READ["&nbsp;on every read&nbsp;"]
+        E["encrypt<br/><small>JWE</small>"]
+    end
+    B(["Provider B"])
+
+    BD ==> E ==> B
+
+    classDef store fill:#ffffff,stroke:#94a3b8,stroke-width:1px,color:#1a202c
+    classDef op fill:#ebf4fb,stroke:#2b6cb0,stroke-width:1px,color:#12395e
+    classDef guard fill:#fdf6ec,stroke:#b45309,stroke-width:2px,color:#7c3d06
+    classDef out fill:#f3effc,stroke:#6b46c1,stroke-width:1px,color:#3f2a75
+    classDef zone fill:#f7fafc,stroke:#cbd5e0,stroke-width:1px,color:#5a6b82
+    class QR,BD store
+    class E op
+    class P guard
+    class B out
+    class ONCE,READ zone
+```
+
+Redaction runs once, at share time, and the result is persisted. **Reads get cheap and auditable** — you can point at the exact bytes a recipient was served, which matters for a disclosure log or a signed credential (a [SMART Health Card](https://hl7.org/fhir/uv/smart-health-cards-and-links/STU1/) has to be signed over fixed content anyway).
+
+But it gives up the properties this use case asked for. A new assessment does **not** appear — someone must rebuild and re-store it. Tightening what's shared does **not** apply retroactively, because a copy already exists. Revocation stops serving the Bundle but the plaintext is still on disk. Choose this when the share is a snapshot ("the record as of the referral date"); avoid it when it must stay live.
+
+### 4. Server enforces it with Label-based Access Control
+
+```mermaid
+flowchart LR
+    subgraph AB["&nbsp;Aidbox&nbsp;"]
+        QR["QuestionnaireResponse<br/><small>meta.security +<br/>inline element labels</small>"]
+        LB["LBAC<br/><small>filters rows<br/>masks elements</small>"]
+        QR ==> LB
+    end
+    subgraph APP["&nbsp;SHL App&nbsp;"]
+        Q["query<br/><small>with the recipient's<br/>clearance</small>"]
+        E["encrypt<br/><small>JWE</small>"]
+    end
+    B(["Provider B"])
+
+    LB ==>|"already redacted"| Q ==> E ==> B
+
+    classDef store fill:#ffffff,stroke:#94a3b8,stroke-width:1px,color:#1a202c
+    classDef op fill:#ebf4fb,stroke:#2b6cb0,stroke-width:1px,color:#12395e
+    classDef guard fill:#fdf6ec,stroke:#b45309,stroke-width:2px,color:#7c3d06
+    classDef out fill:#f3effc,stroke:#6b46c1,stroke-width:1px,color:#3f2a75
+    classDef zone fill:#f7fafc,stroke:#cbd5e0,stroke-width:1px,color:#5a6b82
+    class QR store
+    class Q,E op
+    class LB guard
+    class B out
+    class AB,APP zone
+```
+
+[LBAC](https://www.health-samurai.io/docs/aidbox/access-control/authorization/label-based-access-control) (`BOX_SECURITY_LBAC_ENABLED`) tags resources via `meta.security` and the requester via JWT `scope`, then enforces in two phases: non-matching rows are filtered **in Postgres** so they never reach the app, and individual elements are masked when the resource carries `PROCESSINLINELABEL` and the elements carry DS4P inline security labels — replaced with a `masked` data-absent-reason, the same marker this app writes by hand.
+
+### Choosing
+
+| | Redaction enforced by | Stays live | Retroactive policy change | Reusable by other clients | Cost |
+|---|---|---|---|---|---|
+| **1. App filters** | app code | yes | yes | no | lowest |
+| **2. Server extracts** | app code, over discrete resources | yes | needs provenance | resources are | medium |
+| **3. Pre-built Bundle** | app code, once | **no** | **no** | the Bundle is | low |
+| **4. LBAC** | the server | yes | yes | **yes** | highest |
+
+This repo uses **1** because the point is to make the sharing mechanics legible in readable code. For production, **4** is where the field-level rules belong — the app cannot leak what it never receives — with **2** layered in when the recipient wants data for their chart rather than a form to read. Reach for **3** only when the share is deliberately a snapshot.
+
+## Two things worth calling out
+
+### Withheld, not missing
+
+Silently dropping a question is worse than saying it was dropped: the receiving clinician can't tell "the patient didn't answer" from "the sender wouldn't show me." So a hidden item keeps its `linkId` and question text, loses its answer, and gains a `masked` data-absent-reason:
+
+```json
+{
+  "linkId": "gad7-q4",
+  "text": "Trouble relaxing",
+  "extension": [
+    { "url": "http://example.org/fhir/StructureDefinition/data-absent-reason",
+      "valueCode": "masked" }
+  ]
+}
+```
+
+### The score is a back door
+
+A GAD-7 total is the sum of its seven scored items. Hide one item but publish the total, and the hidden answer is exactly `total − sum(visible)` — the redaction is undone by arithmetic. So:
+
+- with `shareScore: false`, no score is sent at all;
+- with `shareScore: true` **and** any scored item hidden, the score is recomputed from the *visible* items only, so it can never act as an oracle.
+
+See `src/services/redaction.ts`.
+
+## Aidbox resources
+
+The [init bundle](init-bundle/bundle.json) provisions the configuration and demo data at startup. The flow creates the rest at runtime.
+
+| Resource | Created | Why |
+|----------|---------|-----|
+| `Client/share-client` | init bundle | The M2M client the Bun app uses to call Aidbox's FHIR API (Basic auth). |
+| `AccessPolicy/share-client-policy` | init bundle | Grants `share-client` access to Aidbox (`allow` engine). |
+| `StructureDefinition/AssessmentShare` | init bundle | Defines the `AssessmentShare` [custom resource](https://www.health-samurai.io/docs/aidbox/tutorials/artifact-registry-tutorials/custom-resources): one sharing grant — parties, patient, window, hidden items, passcode state, file tokens, access log. |
+| `App/share-app` | init bundle | Registers the app and routes the four operations. |
+| `Questionnaire/gad7` + `CodeSystem` + two `ValueSet`s | init bundle | The GAD-7 instrument. The form renderer reads this resource directly, so the instrument is defined once here rather than in code. Its items carry inline `answerOption` (see "Notes & scope"); the `CodeSystem`/`ValueSet` remain the terminology of record. |
+| `Organization/provider-a`, `Organization/provider-b` | init bundle | The sharing and receiving organizations. |
+| `Patient/patient-jane-roe` | init bundle | A demo patient to record assessments against. |
+| `QuestionnaireResponse/{id}` | runtime, one per assessment | A completed GAD-7, stamped with the sharing organization as `source`. |
+| `AssessmentShare/{id}` | runtime, one per share | The grant: who may read what, when, and with which items withheld. |
+
+## Endpoints
+
+All four are Aidbox App operations, proxied to the Bun service. Manifest and file are **public** (bound to an `allow` policy); create and revoke are authenticated.
+
+| Operation | Method | Path | Auth | Purpose |
+|-----------|--------|------|------|---------|
+| `share-create` | POST | `/share-app/shares/$create` | required | Grant time-bounded access, mint a `shlink:` |
+| `share-revoke` | POST | `/share-app/shares/{shareId}/$revoke` | required | Close a share before its end date |
+| `share-manifest` | POST | `/share-app/manifest/{shareId}` | public | SHL manifest request |
+| `share-file` | GET | `/share-app/file/{fileId}` | public | Short-lived encrypted file fetch |
+
+The Bun app also serves the demo UI directly (not via Aidbox) on port 3100: `GET /` plus a handful of unauthenticated `/demo/*` routes the page uses; see "Testing the flow".
+
+## Quick Start
+
+### Prerequisites
+- Docker and Docker Compose
+- [Bun](https://bun.sh) 1.x (for local development)
+
+### Running the application
+
+1. **Create .env file** (optional; defaults match `docker-compose.yaml`):
+   ```bash
+   cp .env.example .env
+   ```
+
+2. **Run docker compose**:
+   ```bash
+   docker compose up --build
+   ```
+
+3. **Initialize Aidbox**: navigate to the [Aidbox UI](http://localhost:8080) and [activate the instance](https://www.health-samurai.io/docs/aidbox/getting-started/run-aidbox-locally#activate-your-aidbox-instance). The init bundle registers the client, the `AssessmentShare` custom resource, the `share-app` App, the GAD-7 questionnaire, and the demo organizations and patient.
+
+4. **Open the app**: [http://localhost:3100](http://localhost:3100). Minted links open it prefilled.
+
+### Local development (without Docker for the app)
+
+```bash
+bun install
+bun run dev      # watch mode
+```
+
+## Testing the flow
+
+### The whole use case in the browser (recommended)
+
+Open **[http://localhost:3100](http://localhost:3100)**. Four tabs walk the two organizations' halves:
+
+1. **Complete a GAD-7.** The form is rendered by [`@formbox/renderer`](https://github.com/HealthSamurai/formbox-renderer) from the `Questionnaire/gad7` resource in Aidbox — the same renderer [HealthSamurai/phr](https://github.com/HealthSamurai/phr) uses. Answer the seven scored items (the eighth, functional impairment, is standard but not scored) and submit; it lands in Aidbox as a `QuestionnaireResponse` attributed to the sharing organization. Save a couple so there's a history.
+2. **Share it.** Pick the patient and the receiving organization, set the window, and tick any question to hold back. Optionally set a passcode (delivered out-of-band) and decide whether the total score travels. You get a `shlink:` back.
+3. **Manage shares.** Every grant with its window, what it withholds, and when the recipient read it — plus **Close now** to end one early.
+4. **Open a link.** The real receiver half: paste the `shlink:`, and the page decodes it, polls the manifest, fetches the ciphertext, and decrypts it with WebCrypto. Withheld questions show as *withheld*; a suppressed score shows as *score withheld*. Expand **Behind the scenes** to see each HTTP call and its live response.
+
+Three things worth trying once it's running:
+
+- **Watch the share stay live.** Open the link, go back to tab 1, save another assessment, then reopen the link — the new one is there. Nothing was re-minted.
+- **Watch it close.** Create a share ending two minutes out, then reopen the link after. Or hit **Close now** and reopen immediately.
+- **Watch the score close the leak.** Share with question 4 hidden and the score on, and compare the total against the visible answers — it sums only what you can see.
+
+> The UI's first three tabs call unauthenticated `/demo/*` routes so the browser holds no Aidbox credentials. In production those are the authenticated `share-create` / `share-revoke` operations, triggered from the sharing organization's own system.
+
+### The same flow at the API level
+
+Use the [Aidbox REST Console](http://localhost:8080/u/rest) or `curl`.
+
+#### 1. Record a GAD-7
+
+```http
+POST /fhir/QuestionnaireResponse
+Content-Type: application/fhir+json
+
+{
+  "resourceType": "QuestionnaireResponse",
+  "questionnaire": "http://example.org/fhir/Questionnaire/gad7",
+  "status": "completed",
+  "subject": { "reference": "Patient/patient-jane-roe" },
+  "author": { "reference": "Organization/provider-a" },
+  "authored": "2026-07-01T10:00:00Z",
+  "item": [
+    { "linkId": "gad7-q1", "text": "Feeling nervous, anxious, or on edge",
+      "answer": [{ "valueCoding": {
+        "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+        "code": "nearly-every-day", "display": "Nearly every day" } }] }
+  ]
+}
+```
+
+`author` is what scopes a share to one organization's own assessments — not `source`, which FHIR restricts to a person (`Patient | Practitioner | PractitionerRole | RelatedPerson`). The spec is explicit that responses "authored by other collections of people must use Organization".
+
+#### 2. Create a share
+
+```http
+POST /share-app/shares/$create
+Content-Type: application/fhir+json
+
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    { "name": "patient",               "valueString": "Patient/patient-jane-roe" },
+    { "name": "recipientOrganization", "valueString": "Organization/provider-b" },
+    { "name": "recipientDisplay",      "valueString": "Riverside Psychiatry Group" },
+    { "name": "end",                   "valueString": "2026-09-01T00:00:00Z" },
+    { "name": "hiddenItems",           "valueString": "gad7-q4,gad7-q8" },
+    { "name": "shareScore",            "valueString": "true" }
+  ]
+}
+```
+
+Response:
+```json
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    { "name": "shareId",     "valueString": "3f9a..." },
+    { "name": "shlink",      "valueString": "shlink:/eyJ1cmwiOiJodHRw..." },
+    { "name": "manifestUrl", "valueString": "http://localhost:8080/share-app/manifest/3f9a..." },
+    { "name": "expiresAt",   "valueString": "2026-09-01T00:00:00.000Z" }
+  ]
+}
+```
+
+`start` defaults to now; `end` is required and becomes the link's `exp`.
+
+#### 3. Poll the manifest (no auth required)
+
+```http
+POST /share-app/manifest/{shareId}
+Content-Type: application/json
+
+{ "recipient": "Riverside Psychiatry Group" }
+```
+
+While the window is open:
+```json
+{
+  "status": "can-change",
+  "files": [
+    { "contentType": "application/fhir+json", "embedded": "<JWE compact serialization>" }
+  ]
+}
+```
+
+`can-change` is the honest status for a live share — more assessments may still arrive. Once the window closes (end date passed, or revoked):
+```json
+{ "status": "no-longer-valid", "files": [] }
+```
+
+If you send `embeddedLengthMax` smaller than the JWE, the manifest returns a short-lived `location` URL instead:
+```http
+GET /share-app/file/{fileId}    # returns the JWE as application/jose
+```
+
+#### 4. Close it early
+
+```http
+POST /share-app/shares/{shareId}/$revoke
+```
+
+The next manifest poll resolves to `no-longer-valid`, and any outstanding `location` URLs return `410 Gone`.
+
+#### 5. Decrypt the contents
+
+```ts
+import { decodeShlink } from "./src/utils/shl-encode.ts";
+import { decryptJwe } from "./src/utils/crypto.ts";
+
+const payload = decodeShlink(shlink);          // { url, key, exp, flag: "L", label, v }
+const bundle = JSON.parse(await decryptJwe(jwe, payload.key));
+// -> Bundle of redacted QuestionnaireResponses
+```
+
+The bundle carries the terms it was produced under, so the constraints travel with the data:
+
+```json
+{
+  "resourceType": "Bundle",
+  "type": "searchset",
+  "total": 3,
+  "extension": [
+    { "url": "http://example.org/fhir/StructureDefinition/share-window",
+      "extension": [
+        { "url": "start", "valueInstant": "2026-07-29T10:00:00.000Z" },
+        { "url": "end",   "valueInstant": "2026-09-01T00:00:00.000Z" },
+        { "url": "sharedBy",   "valueString": "Organization/provider-a" },
+        { "url": "sharedWith", "valueString": "Riverside Psychiatry Group" }
+      ] },
+    { "url": "http://example.org/fhir/StructureDefinition/share-redaction",
+      "extension": [
+        { "url": "withheldItem",  "valueString": "gad7-q4" },
+        { "url": "withheldItem",  "valueString": "gad7-q8" },
+        { "url": "scoreWithheld", "valueBoolean": false }
+      ] }
+  ],
+  "entry": [ /* QuestionnaireResponses, hidden items masked */ ]
+}
+```
+
+## Project layout
+
+```
+src/
+├── server.ts                       # Bun.serve; dispatches Aidbox operations, bundles + serves the UI
+├── app.html                        # browser app: share builder, dashboard, receiver (no build)
+├── forms/
+│   └── intake.tsx                  # React island: GAD-7 rendered by @formbox/renderer
+├── handlers/
+│   └── share.ts                    # create / revoke / manifest / file handlers
+├── services/
+│   ├── fhir-client.ts              # wraps @health-samurai/aidbox-client (Basic auth)
+│   ├── share-store.ts              # AssessmentShare custom-resource persistence
+│   ├── assessment-service.ts       # GAD-7 capture + live query, score computation
+│   ├── redaction.ts                # item masking + score-leak prevention
+│   ├── share-content.ts            # builds the shared Bundle on every read
+│   └── share-service.ts            # SHL protocol engine: window, passcode, tokens, throttle
+├── types/
+│   ├── config.ts                   # env-driven config
+│   ├── operation.ts                # Aidbox operation request envelope
+│   ├── shl.ts                      # SHL payload / manifest types
+│   ├── fhir.ts                     # minimal FHIR shapes the app touches
+│   ├── gad7.ts                     # the GAD-7 instrument + scoring
+│   └── assessment-share-resource.ts # AssessmentShare custom resource shape
+└── utils/
+    ├── crypto.ts                   # key generation + JWE encrypt/decrypt (jose)
+    └── shl-encode.ts               # shlink: encode/decode
+```
+
+## Protocol hardening
+
+The example also implements the security-sensitive plumbing of the SHL spec, the parts you don't want every integrator reimplementing:
+
+- **Passcode (`P` flag)**: pass a `passcode` and the link carries `flag: "LP"`. The manifest then requires it. A missing one returns `401 { "message": "Passcode required" }`, a wrong one returns `401 { "remainingAttempts": N }`. The attempt counter is a **lifetime** total persisted on the `AssessmentShare` (and decremented before responding), so it holds up against parallel guessing. Once it hits zero the share locks, and even the correct passcode then resolves to `no-longer-valid`.
+- **Short-lived `location` URLs**: when the manifest hands back a `location` instead of an `embedded` file, it mints a per-request token with an expiry (`SHL_FILE_TOKEN_TTL_SECONDS`, default 60s; the spec allows ≤ 1 hour). Fetching after it expires returns `410 Gone` — and so does fetching after the *share* closes, since revocation has to invalidate URLs already handed out. Because content is rebuilt per read, each token stores the exact ciphertext its manifest advertised.
+- **Poll throttling**: polling one share's manifest faster than `SHL_MANIFEST_MIN_INTERVAL_SECONDS` returns `429` with a `Retry-After` header, which the UI honors.
+- **Access log**: each resolved poll appends the self-declared recipient, the time, and how many assessments were visible — the accountability half of a time-bounded grant, surfaced in the "Manage shares" tab.
+
+Tunable via env (see `.env.example`): `SHL_PASSCODE_MAX_ATTEMPTS`, `SHL_FILE_TOKEN_TTL_SECONDS`, `SHL_MANIFEST_MIN_INTERVAL_SECONDS`, `SHARE_DEFAULT_WINDOW_DAYS`, `SHARE_SOURCE_ORGANIZATION`.
+
+## Notes & scope
+
+- **Flags**: uses `L` (long-term, since contents evolve while the window is open) and optionally `P` (passcode). It does not implement `U` (direct file). A share is never `finalized`; it goes from `can-change` straight to `no-longer-valid`.
+- **Key storage**: the SHL key is persisted on the `AssessmentShare` so each manifest poll can encrypt a freshly built bundle. In production you'd avoid long-term key storage. This is the one deliberate simplification, called out because it's the central security tradeoff of the design.
+- **Bearer link**: the link itself is the credential — `recipientOrganization` is recorded for the audit trail, not verified. Anyone holding the link (and passcode, if set) can read it within the window. Binding a share to an authenticated recipient identity would mean SMART on FHIR rather than SHL.
+- **Inline `answerOption` rather than `answerValueSet`**: the GAD-7's items carry their answer choices inline. Aidbox's hybrid terminology engine returned an empty expansion for the stored `ValueSet`s (the same `compose` expanded correctly when posted inline), and `ValueSet/$expand` needs credentials the browser doesn't hold. Inline options remove both the round trip and the auth problem. The `CodeSystem`/`ValueSet` resources stay in the init bundle as the terminology of record.
+- **The form needs a bundler; the rest of the UI doesn't.** `@formbox/renderer` ships ESM with bare specifiers (react, mobx, fhirpath, ucum-lhc), so the intake tab is compiled by `Bun.build()` at server startup into `/assets/intake.js` (~2.4 MB) and `/assets/intake.css`. There's still no build command to run — `bun src/server.ts` does it. The receiver view stays hand-written because rendering *redacted* responses (showing withheld items as withheld) is exactly what a form renderer doesn't do.
+- **Out of scope**: real-world consent modelling (`Consent` resources), recipient identity verification, `location` single-use enforcement (only expiry and window are enforced), key rotation, sharing more than one instrument per share, and SDC `$extract` (the renderer produces a `QuestionnaireResponse`; nothing maps it onto other resources).

--- a/aidbox-integrations/shared-assessment-link/bun.lock
+++ b/aidbox-integrations/shared-assessment-link/bun.lock
@@ -1,0 +1,412 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "aidbox-shared-assessment-link",
+      "dependencies": {
+        "@formbox/hs-theme": "^0.4.1",
+        "@formbox/renderer": "^0.4.1",
+        "@health-samurai/aidbox-client": "^0.0.0-alpha.4",
+        "@lhncbc/ucum-lhc": "^7.1.9",
+        "classnames": "^2.5.1",
+        "fhirpath": "^4.6.0",
+        "jose": "^5.2.0",
+        "mobx": "^6.16.1",
+        "mobx-react-lite": "^4.1.1",
+        "mobx-utils": "^6.1.1",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.1.0",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@typescript-eslint/eslint-plugin": "^6.20.0",
+        "@typescript-eslint/parser": "^6.20.0",
+        "eslint": "^8.56.0",
+        "prettier": "^3.2.5",
+        "typescript": "^5.3.3",
+      },
+    },
+  },
+  "packages": {
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.10.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@2.1.4", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^9.6.0", "globals": "^13.19.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.0", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ=="],
+
+    "@eslint/js": ["@eslint/js@8.57.1", "", {}, "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="],
+
+    "@formbox/fhir": ["@formbox/fhir@0.4.1", "", { "dependencies": { "@types/fhir": "^0.0.41" } }, "sha512-mfK6eB1Au0M5SK/r6/50lTA1iCs+cJ5KUxlOs/D67qcIlKRjbCZ3AmV0zwt6NUtVkZ+yYdYUJyO2Rg5bIhwaug=="],
+
+    "@formbox/hs-theme": ["@formbox/hs-theme@0.4.1", "", { "dependencies": { "@formbox/theme": "0.4.1", "classnames": "^2.5.1", "perfect-freehand": "^1.2.3" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-XyglX/iugV3D/s4S3zd7dtS9JS5vk4UmPNWMt7ITRrTQbUpkLpH5dhMNcwdPA3Olq61vBliCYjMu8ieBQZ6Z3w=="],
+
+    "@formbox/renderer": ["@formbox/renderer@0.4.1", "", { "dependencies": { "@formbox/fhir": "0.4.1", "@formbox/strings": "0.4.1", "@formbox/theme": "0.4.1", "fuzzy-search": "^3.2.1", "hashery": "^1.4.0" }, "peerDependencies": { "@lhncbc/ucum-lhc": "^7.1.3", "classnames": "^2.5.1", "fhirpath": "^4.6.0", "mobx": "^6.15.0", "mobx-react-lite": "^4.1.1", "mobx-utils": "^6.1.1", "react": ">=18", "react-dom": ">=18" } }, "sha512-pGQ2nqhWhrtJcm0rjyU30EJyzZsxKOANjw036kqFYeyHE2CBpZm+7zUngjcjpjxPlwHTvsCMlfqErX67KRXXvA=="],
+
+    "@formbox/strings": ["@formbox/strings@0.4.1", "", { "dependencies": { "@formbox/theme": "0.4.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-olAdvm3o2y4OkOE1NiN2m553I7Ku3jq8hBtpy8iEEM+IO8l+JoSjImEyQqDHLGXigJpmVdvJJ64UN6X2yszN1Q=="],
+
+    "@formbox/theme": ["@formbox/theme@0.4.1", "", { "dependencies": { "perfect-freehand": "^1.2.3" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-D+4eLAdpNE7awB/WhLPJ287++YSeyCNeYjhUyuzJkCX2heBUao8n1b9gzfFdfZT+QkSK37BMKNS1iMXOOMUvgg=="],
+
+    "@health-samurai/aidbox-client": ["@health-samurai/aidbox-client@0.0.0-alpha.7", "", { "dependencies": { "@types/json-patch": "^0.0.33", "oauth4webapi": "^3.8.5", "yaml": "^2.8.3" } }, "sha512-mXO3t+6nyCUUeN03zs+1+PtatstjwlB2zPVLBrYL43ONiCnCvTeD6UHyJV96VH6eQaeMoBgzx53VvWsLPZOo8A=="],
+
+    "@humanwhocodes/config-array": ["@humanwhocodes/config-array@0.13.0", "", { "dependencies": { "@humanwhocodes/object-schema": "^2.0.3", "debug": "^4.3.1", "minimatch": "^3.0.5" } }, "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/object-schema": ["@humanwhocodes/object-schema@2.0.3", "", {}, "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="],
+
+    "@lhncbc/ucum-lhc": ["@lhncbc/ucum-lhc@7.1.9", "", { "dependencies": { "coffeescript": "^2.7.0", "csv-parse": "^4.4.6", "csv-stringify": "^1.0.4", "escape-html": "^1.0.3", "is-integer": "^1.0.6", "jsonfile": "^2.2.3", "stream-transform": "^0.1.1", "string-to-stream": "^1.1.0", "xmldoc": "^0.4.0" } }, "sha512-LgA+ElIlKrtmogYvk4n3PhExF25WZq0THkHF/UtW4SWct/pxt8ZpXGG1QwQiSs1JWUVpAsgRvyK931FZ1URiow=="],
+
+    "@loxjs/url-join": ["@loxjs/url-join@1.0.2", "", {}, "sha512-BqzK8+iHqxUbPRZV6NBum63CJzE0G6vGG3o+4dqeIzbywdoTg+xHJbksYDkk1P1w3Gj64U20Rgp44HHciLbRzg=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/fhir": ["@types/fhir@0.0.41", "", {}, "sha512-MAQAFufNZBZ6V0F94Nhknmmh/E3iMXFK4n/L8RkSNjKtOJnvaAJERivNOj35VVx9VCQBJbE0BHSzikfBahoRhA=="],
+
+    "@types/json-patch": ["@types/json-patch@0.0.33", "", {}, "sha512-XQ9hIoJCtnvTCnIV+p+SWQbY8Bt1pe+RuTkPG7lQeRCa9sPwYbhb0aYzM2paVPk0SGvV70R33rxjPjBcJ4Kdxw=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+
+    "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@6.21.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.5.1", "@typescript-eslint/scope-manager": "6.21.0", "@typescript-eslint/type-utils": "6.21.0", "@typescript-eslint/utils": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0", "debug": "^4.3.4", "graphemer": "^1.4.0", "ignore": "^5.2.4", "natural-compare": "^1.4.0", "semver": "^7.5.4", "ts-api-utils": "^1.0.1" }, "peerDependencies": { "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha", "eslint": "^7.0.0 || ^8.0.0", "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@6.21.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "6.21.0", "@typescript-eslint/types": "6.21.0", "@typescript-eslint/typescript-estree": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0", "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@6.21.0", "", { "dependencies": { "@typescript-eslint/types": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0" } }, "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@6.21.0", "", { "dependencies": { "@typescript-eslint/typescript-estree": "6.21.0", "@typescript-eslint/utils": "6.21.0", "debug": "^4.3.4", "ts-api-utils": "^1.0.1" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@6.21.0", "", {}, "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@6.21.0", "", { "dependencies": { "@typescript-eslint/types": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0", "debug": "^4.3.4", "globby": "^11.1.0", "is-glob": "^4.0.3", "minimatch": "9.0.3", "semver": "^7.5.4", "ts-api-utils": "^1.0.1" } }, "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@6.21.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.4.0", "@types/json-schema": "^7.0.12", "@types/semver": "^7.5.0", "@typescript-eslint/scope-manager": "6.21.0", "@typescript-eslint/types": "6.21.0", "@typescript-eslint/typescript-estree": "6.21.0", "semver": "^7.5.4" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@6.21.0", "", { "dependencies": { "@typescript-eslint/types": "6.21.0", "eslint-visitor-keys": "^3.4.1" } }, "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.3", "", {}, "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg=="],
+
+    "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "antlr4": ["antlr4@4.9.3", "", {}, "sha512-qNy2odgsa0skmNMCuxzXhM4M8J1YDaPv3TI+vCdnOAanu0N982wBrSqziDKRDctEZLZy9VffqIZXc0UGjjSP/g=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "brace-expansion": ["brace-expansion@1.1.17", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "classnames": ["classnames@2.5.1", "", {}, "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="],
+
+    "coffeescript": ["coffeescript@2.7.0", "", { "bin": { "coffee": "bin/coffee", "cake": "bin/cake" } }, "sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "csv-parse": ["csv-parse@4.16.3", "", {}, "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg=="],
+
+    "csv-stringify": ["csv-stringify@1.1.2", "", { "dependencies": { "lodash.get": "~4.4.2" } }, "sha512-3NmNhhd+AkYs5YtM1GEh01VR6PKj6qch2ayfQaltx5xpcAdThjnbbI5eT8CzRVpXfGKAxnmrSYLsNl/4f3eWiw=="],
+
+    "date-fns": ["date-fns@1.30.1", "", {}, "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
+
+    "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
+
+    "emitter-component": ["emitter-component@1.1.2", "", {}, "sha512-QdXO3nXOzZB4pAjM0n6ZE+R9/+kPpECA/XSELIcc54NeYVnBqIk+4DFiBgK+8QbV3mdvTG6nedl7dTYgO+5wDw=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@8.57.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.6.1", "@eslint/eslintrc": "^2.1.4", "@eslint/js": "8.57.1", "@humanwhocodes/config-array": "^0.13.0", "@humanwhocodes/module-importer": "^1.0.1", "@nodelib/fs.walk": "^1.2.8", "@ungap/structured-clone": "^1.2.0", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.2", "debug": "^4.3.2", "doctrine": "^3.0.0", "escape-string-regexp": "^4.0.0", "eslint-scope": "^7.2.2", "eslint-visitor-keys": "^3.4.3", "espree": "^9.6.1", "esquery": "^1.4.2", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^6.0.1", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "globals": "^13.19.0", "graphemer": "^1.4.0", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "is-path-inside": "^3.0.3", "js-yaml": "^4.1.0", "json-stable-stringify-without-jsonify": "^1.0.1", "levn": "^0.4.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3", "strip-ansi": "^6.0.1", "text-table": "^0.2.0" }, "bin": { "eslint": "bin/eslint.js" } }, "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA=="],
+
+    "eslint-scope": ["eslint-scope@7.2.2", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "espree": ["espree@9.6.1", "", { "dependencies": { "acorn": "^8.9.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^3.4.1" } }, "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
+
+    "fhirpath": ["fhirpath@4.11.0", "", { "dependencies": { "@lhncbc/ucum-lhc": "^5.0.0", "@loxjs/url-join": "^1.0.2", "antlr4": "~4.9.3", "commander": "^14.0.3", "date-fns": "^1.30.1", "decimal.js": "^10.6.0", "js-yaml": "^4.1.1" }, "bin": { "fhirpath": "bin/fhirpath" } }, "sha512-cVrPyAtwsffxgu+eK5yzGNfzPVaH535iduMBhTN5JZFkxMSZdvVfIzCOSFqQkWBoIFZG9aaGDOcXC6i+2tqCVQ=="],
+
+    "file-entry-cache": ["file-entry-cache@6.0.1", "", { "dependencies": { "flat-cache": "^3.0.4" } }, "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@3.2.0", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.3", "rimraf": "^3.0.2" } }, "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw=="],
+
+    "flatted": ["flatted@3.4.3", "", {}, "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
+
+    "fuzzy-search": ["fuzzy-search@3.2.1", "", {}, "sha512-vAcPiyomt1ioKAsAL2uxSABHJ4Ju/e4UeDM+g1OlR0vV4YhLGMNsdLNvZTpEDY4JCSt0E4hASCNM5t2ETtsbyg=="],
+
+    "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@13.24.0", "", { "dependencies": { "type-fest": "^0.20.2" } }, "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ=="],
+
+    "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "hashery": ["hashery@1.5.1", "", { "dependencies": { "hookified": "^1.15.0" } }, "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ=="],
+
+    "hookified": ["hookified@1.15.1", "", {}, "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-finite": ["is-finite@1.1.0", "", {}, "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-integer": ["is-integer@1.0.7", "", { "dependencies": { "is-finite": "^1.0.0" } }, "sha512-RPQc/s9yBHSvpi+hs9dYiJ2cuFeU6x3TyyIp8O2H6SKEltIvJOzRj9ToyvcStDvPR/pS4rxgr1oBFajQjZ2Szg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-path-inside": ["is-path-inside@3.0.3", "", {}, "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="],
+
+    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+
+    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "jsonfile": ["jsonfile@2.4.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.get": ["lodash.get@4.4.2", "", {}, "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "mobx": ["mobx@6.16.1", "", {}, "sha512-syNcDdX3KT+Jq3je6eGjBhuc24Z68td2VG0zNFqRswaE433D9SNH5VRy/xrGbJsUixfppLLccXhAW9JSf6n+SQ=="],
+
+    "mobx-react-lite": ["mobx-react-lite@4.1.1", "", { "dependencies": { "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "mobx": "^6.9.0", "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-iUxiMpsvNraCKXU+yPotsOncNNmyeS2B5DKL+TL6Tar/xm+wwNJAubJmtRSeAoYawdZqwv8Z/+5nPRHeQxTiXg=="],
+
+    "mobx-utils": ["mobx-utils@6.1.1", "", { "peerDependencies": { "mobx": "^6.0.0" } }, "sha512-ZR4tOKucWAHOdMjqElRl2BEvrzK7duuDdKmsbEbt2kzgVpuLuoYLiDCjc3QwWQl8CmOlxPgaZQpZ7emwNqPkIg=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "oauth4webapi": ["oauth4webapi@3.8.6", "", {}, "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
+
+    "perfect-freehand": ["perfect-freehand@1.2.3", "", {}, "sha512-bHZSfqDHGNlPpgH2yxXgPHlQSPpEbo+qg7li0M78J9vNAi2yjwLeA4x79BEQhX44lEWpCLSFCeRZwpw0niiXPA=="],
+
+    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
+
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
+
+    "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
+
+    "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "sax": ["sax@1.1.6", "", {}, "sha512-8zci48uUQyfqynGDSkUMD7FCJB96hwLnlZOXlgs1l3TX+LW27t3psSWKUxC0fxVgA86i8tL4NwGcY1h/6t3ESg=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+
+    "stream": ["stream@0.0.2", "", { "dependencies": { "emitter-component": "^1.1.1" } }, "sha512-gCq3NDI2P35B2n6t76YJuOp7d6cN/C7Rt0577l91wllh0sY9ZBuw9KaSGqH/b0hzn3CWWJbpbW0W0WvQ1H/Q7g=="],
+
+    "stream-transform": ["stream-transform@0.1.2", "", {}, "sha512-3HXId/0W8sktQnQM6rOZf2LuDDMbakMgAjpViLk758/h0br+iGqZFFfUxxJSqEvGvT742PyFr4v/TBXUtowdCg=="],
+
+    "string-to-stream": ["string-to-stream@1.1.1", "", { "dependencies": { "inherits": "^2.0.1", "readable-stream": "^2.1.0" } }, "sha512-QySF2+3Rwq0SdO3s7BAp4x+c3qsClpPQ6abAmb0DGViiSBAkT5kL6JT2iyzEVP+T1SmzHrQD1TwlP9QAHCc+Sw=="],
+
+    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "text-table": ["text-table@0.2.0", "", {}, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "ts-api-utils": ["ts-api-utils@1.4.3", "", { "peerDependencies": { "typescript": ">=4.2.0" } }, "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "xmldoc": ["xmldoc@0.4.0", "", { "dependencies": { "sax": "~1.1.1" } }, "sha512-rJ/+/UzYCSlFNuAzGuRyYgkH2G5agdX1UQn4+5siYw9pkNC3Hu/grYNDx/dqYLreeSjnY5oKg74CMBKxJHSg6Q=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.3", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg=="],
+
+    "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "fhirpath/@lhncbc/ucum-lhc": ["@lhncbc/ucum-lhc@5.0.4", "", { "dependencies": { "coffeescript": "^2.7.0", "csv-parse": "^4.4.6", "csv-stringify": "^1.0.4", "escape-html": "^1.0.3", "is-integer": "^1.0.6", "jsonfile": "^2.2.3", "stream": "0.0.2", "stream-transform": "^0.1.1", "string-to-stream": "^1.1.0", "xmldoc": "^0.4.0" } }, "sha512-khuV9GV51DF80b0wJmhZTR5Bf23fhS6SSIWnyGT9X+Uvn0FsHFl2LKViQ2TTOuvwagUOUSq8/0SyoE2ZDGwrAA=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.1.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A=="],
+  }
+}

--- a/aidbox-integrations/shared-assessment-link/docker-compose.yaml
+++ b/aidbox-integrations/shared-assessment-link/docker-compose.yaml
@@ -1,0 +1,103 @@
+volumes:
+  postgres_data: {}
+
+services:
+  postgres:
+    image: postgres:18
+    volumes:
+      - postgres_data:/var/lib/postgresql:delegated
+    command:
+      - postgres
+      - -c
+      - shared_preload_libraries=pg_stat_statements
+    environment:
+      POSTGRES_USER: aidbox
+      POSTGRES_PORT: "5432"
+      POSTGRES_DB: aidbox
+      POSTGRES_PASSWORD: hb1NnSed7w
+
+  aidbox:
+    image: healthsamurai/aidboxone:edge
+    pull_policy: always
+    depends_on:
+      - postgres
+    ports:
+      - 8080:8080
+    volumes:
+      - ./init-bundle:/app/init-bundle:ro
+    environment:
+      BOX_ADMIN_PASSWORD: uN6jhgu8eo
+      BOX_BOOTSTRAP_FHIR_PACKAGES: hl7.fhir.r4.core#4.0.1
+      BOX_COMPATIBILITY_VALIDATION_JSON__SCHEMA_REGEX: "#{:fhir-datetime}"
+      BOX_DB_DATABASE: aidbox
+      BOX_DB_HOST: postgres
+      BOX_DB_PASSWORD: hb1NnSed7w
+      BOX_DB_PORT: "5432"
+      BOX_DB_USER: aidbox
+      BOX_FHIR_COMPLIANT_MODE: true
+      BOX_FHIR_CORRECT_AIDBOX_FORMAT: true
+      BOX_FHIR_CREATEDAT_URL: https://aidbox.app/ex/createdAt
+      BOX_FHIR_SCHEMA_VALIDATION: true
+      BOX_FHIR_SEARCH_AUTHORIZE_INLINE_REQUESTS: true
+      BOX_FHIR_SEARCH_CHAIN_SUBSELECT: true
+      BOX_FHIR_SEARCH_COMPARISONS: true
+      BOX_FHIR_TERMINOLOGY_ENGINE: hybrid
+      BOX_FHIR_TERMINOLOGY_ENGINE_HYBRID_EXTERNAL_TX_SERVER: https://tx.health-samurai.io/fhir
+      BOX_FHIR_TERMINOLOGY_SERVICE_BASE_URL: https://tx.health-samurai.io/fhir
+      BOX_MODULE_SDC_STRICT_ACCESS_CONTROL: true
+      BOX_ROOT_CLIENT_SECRET: qNbQS6sw82
+      BOX_RUNME_UUID: 7c429b2a-14af-4859-ae12-7e23e46be07d
+      BOX_SEARCH_INCLUDE_CONFORMANT: true
+      BOX_SECURITY_AUDIT_LOG_ENABLED: true
+      BOX_SECURITY_DEV_MODE: true
+      BOX_SETTINGS_MODE: read-write
+      BOX_WEB_BASE_URL: http://localhost:8080
+      BOX_WEB_PORT: 8080
+      BOX_INIT_BUNDLE: file:///app/init-bundle/bundle.json
+    healthcheck:
+      test: curl -f http://localhost:8080/health || exit 1
+      interval: 5s
+      timeout: 5s
+      retries: 90
+      start_period: 30s
+
+  share-app:
+    build: .
+    ports:
+      # Published on 3100 to stay clear of the common 3000 default.
+      - 3100:3000
+    depends_on:
+      aidbox:
+        condition: service_healthy
+    environment:
+      PORT: 3000
+      NODE_ENV: production
+
+      # Aidbox FHIR API access (Basic auth client from the init bundle).
+      # Bare host — the Aidbox client appends /fhir itself.
+      AIDBOX_BASE_URL: http://aidbox:8080
+      AIDBOX_CLIENT_ID: share-client
+      AIDBOX_CLIENT_SECRET: secret
+
+      # Public base URL of the SHL endpoints, as the recipient reaches them
+      # (operations are proxied through Aidbox under /share-app/...).
+      SHL_PUBLIC_BASE_URL: http://localhost:8080/share-app
+      # Minted shlink: values are prefixed so they open the in-app viewer with
+      # the link prefilled (the viewer reads it from the URL fragment).
+      SHL_VIEWER_URL: "http://localhost:3100/#"
+
+      # The organization this deployment shares as (Provider A)
+      SHARE_SOURCE_ORGANIZATION: Organization/provider-a
+      # Default sharing window length when the caller doesn't give an end date
+      SHARE_DEFAULT_WINDOW_DAYS: 30
+
+      # SHL protocol policy (passcode attempts, location TTL, poll throttle)
+      SHL_PASSCODE_MAX_ATTEMPTS: 5
+      SHL_FILE_TOKEN_TTL_SECONDS: 60
+      SHL_MANIFEST_MIN_INTERVAL_SECONDS: 1
+    healthcheck:
+      test: curl -f http://localhost:3000/health || exit 1
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s

--- a/aidbox-integrations/shared-assessment-link/eslint.config.cjs
+++ b/aidbox-integrations/shared-assessment-link/eslint.config.cjs
@@ -1,0 +1,24 @@
+module.exports = [
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parser: require('@typescript-eslint/parser'),
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+        project: './tsconfig.json'
+      }
+    },
+    plugins: {
+      '@typescript-eslint': require('@typescript-eslint/eslint-plugin')
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'warn',
+      '@typescript-eslint/no-explicit-any': 'warn',
+      'no-console': 'warn',
+      'prefer-const': 'error',
+      'no-var': 'error'
+    }
+  }
+];

--- a/aidbox-integrations/shared-assessment-link/init-bundle/bundle.json
+++ b/aidbox-integrations/shared-assessment-link/init-bundle/bundle.json
@@ -1,0 +1,928 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Client",
+        "id": "share-client",
+        "secret": "secret",
+        "grant_types": [
+          "basic"
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Client/share-client"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "AccessPolicy",
+        "id": "share-client-policy",
+        "engine": "allow",
+        "link": [
+          {
+            "id": "share-client",
+            "resourceType": "Client"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "AccessPolicy/share-client-policy"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "StructureDefinition",
+        "id": "AssessmentShare",
+        "url": "http://example.org/fhir/StructureDefinition/AssessmentShare",
+        "name": "AssessmentShare",
+        "status": "active",
+        "kind": "resource",
+        "abstract": false,
+        "type": "AssessmentShare",
+        "baseDefinition": "http://hl7.org/fhir/StructureDefinition/DomainResource",
+        "derivation": "specialization",
+        "differential": {
+          "element": [
+            {
+              "id": "AssessmentShare",
+              "path": "AssessmentShare",
+              "min": 0,
+              "max": "*",
+              "short": "A time-bounded, field-redacted assessment share",
+              "definition": "One grant of access from a sharing provider organization to a receiving one: which patient's assessments, over which time window, with which items withheld. This is a sharing *policy*, not a snapshot \u2014 the content it exposes is rebuilt from live data on every manifest request, which is what lets new assessments appear automatically and lets revocation take effect immediately."
+            },
+            {
+              "id": "AssessmentShare.key",
+              "path": "AssessmentShare.key",
+              "min": 1,
+              "max": "1",
+              "type": [
+                {
+                  "code": "string"
+                }
+              ],
+              "short": "Content-encryption key",
+              "definition": "The base64url-encoded 256-bit AES key that encrypts this share's payload. It also travels inside the shlink: URI, so only the recipient holding the link can decrypt what the manifest serves."
+            },
+            {
+              "id": "AssessmentShare.label",
+              "path": "AssessmentShare.label",
+              "min": 1,
+              "max": "1",
+              "type": [
+                {
+                  "code": "string"
+                }
+              ],
+              "short": "Human-readable label",
+              "definition": "Short description of what the share carries, shown to the recipient (e.g. \"GAD-7 assessments for Jane Roe\")."
+            },
+            {
+              "id": "AssessmentShare.sourceOrganization",
+              "path": "AssessmentShare.sourceOrganization",
+              "min": 1,
+              "max": "1",
+              "type": [
+                {
+                  "code": "string"
+                }
+              ],
+              "short": "The sharing organization (Provider A)",
+              "definition": "Reference to the organization granting access, e.g. 'Organization/provider-a'. Assessments are scoped to those this organization authored, so a share never exposes another organization's data about the same patient."
+            },
+            {
+              "id": "AssessmentShare.recipientOrganization",
+              "path": "AssessmentShare.recipientOrganization",
+              "min": 1,
+              "max": "1",
+              "type": [
+                {
+                  "code": "string"
+                }
+              ],
+              "short": "The receiving organization (Provider B)",
+              "definition": "Reference to the organization the access is granted to, e.g. 'Organization/provider-b'. Recorded for the audit trail; the link itself is the bearer credential."
+            },
+            {
+              "id": "AssessmentShare.recipientDisplay",
+              "path": "AssessmentShare.recipientDisplay",
+              "min": 0,
+              "max": "1",
+              "type": [
+                {
+                  "code": "string"
+                }
+              ],
+              "short": "Recipient organization name",
+              "definition": "Display name of the receiving organization, so the viewer can name it without resolving the reference."
+            },
+            {
+              "id": "AssessmentShare.patient",
+              "path": "AssessmentShare.patient",
+              "min": 1,
+              "max": "1",
+              "type": [
+                {
+                  "code": "string"
+                }
+              ],
+              "short": "The patient whose assessments are shared",
+              "definition": "Reference to the patient, e.g. 'Patient/123'. One share covers one patient."
+            },
+            {
+              "id": "AssessmentShare.questionnaire",
+              "path": "AssessmentShare.questionnaire",
+              "min": 1,
+              "max": "1",
+              "type": [
+                {
+                  "code": "string"
+                }
+              ],
+              "short": "Canonical URL of the shared instrument",
+              "definition": "Canonical URL of the Questionnaire whose responses are in scope (e.g. the GAD-7). A share covers one instrument rather than the whole chart, which keeps the grant narrow."
+            },
+            {
+              "id": "AssessmentShare.startsAt",
+              "path": "AssessmentShare.startsAt",
+              "min": 1,
+              "max": "1",
+              "type": [
+                {
+                  "code": "integer"
+                }
+              ],
+              "short": "Window start (epoch seconds)",
+              "definition": "Start of the sharing window. Before this moment the manifest resolves to 'can-change' with no files \u2014 the grant exists but has not opened."
+            },
+            {
+              "id": "AssessmentShare.endsAt",
+              "path": "AssessmentShare.endsAt",
+              "min": 1,
+              "max": "1",
+              "type": [
+                {
+                  "code": "integer"
+                }
+              ],
+              "short": "Window end (epoch seconds)",
+              "definition": "End of the sharing window, mirrored into the shlink: payload as 'exp'. From this moment the manifest resolves to 'no-longer-valid' and outstanding file locations return 410 Gone. No job closes the share; the window is evaluated on each read."
+            },
+            {
+              "id": "AssessmentShare.hiddenItems",
+              "path": "AssessmentShare.hiddenItems",
+              "min": 0,
+              "max": "*",
+              "type": [
+                {
+                  "code": "string"
+                }
+              ],
+              "short": "Withheld questionnaire item linkIds",
+              "definition": "linkIds of the questionnaire items the sharing organization chose not to share (e.g. 'gad7-q4'). Each is stripped of its answer and marked with a 'masked' data-absent-reason before encryption, so the recipient can tell a withheld answer from an unanswered question. Because redaction happens on every read, tightening this list applies retroactively to a link already sent."
+            },
+            {
+              "id": "AssessmentShare.shareScore",
+              "path": "AssessmentShare.shareScore",
+              "min": 0,
+              "max": "1",
+              "type": [
+                {
+                  "code": "boolean"
+                }
+              ],
+              "short": "Whether the total score may be shared",
+              "definition": "A GAD-7 total is the sum of its items, so publishing it alongside a partially hidden set can leak the hidden answers. When false the score is omitted entirely; when true and any scored item is hidden, the score is recomputed from the visible items only."
+            },
+            {
+              "id": "AssessmentShare.status",
+              "path": "AssessmentShare.status",
+              "min": 1,
+              "max": "1",
+              "type": [
+                {
+                  "code": "code"
+                }
+              ],
+              "short": "active | revoked",
+              "definition": "'active' while the grant stands; 'revoked' once the sharing organization closed it early. A revoked share resolves to 'no-longer-valid' on the next read regardless of its end date."
+            },
+            {
+              "id": "AssessmentShare.revokedAt",
+              "path": "AssessmentShare.revokedAt",
+              "min": 0,
+              "max": "1",
+              "type": [
+                {
+                  "code": "integer"
+                }
+              ],
+              "short": "Early-revocation time (epoch seconds)",
+              "definition": "When the sharing organization revoked the share. Set only when status is 'revoked'."
+            },
+            {
+              "id": "AssessmentShare.passcode",
+              "path": "AssessmentShare.passcode",
+              "min": 0,
+              "max": "1",
+              "type": [
+                {
+                  "code": "string"
+                }
+              ],
+              "short": "Optional passcode (P flag)",
+              "definition": "When set, the link carries the 'P' flag and the manifest requires this passcode (delivered out-of-band, never inside the shlink:). A second secret guarding against link interception."
+            },
+            {
+              "id": "AssessmentShare.remainingAttempts",
+              "path": "AssessmentShare.remainingAttempts",
+              "min": 0,
+              "max": "1",
+              "type": [
+                {
+                  "code": "integer"
+                }
+              ],
+              "short": "Remaining passcode attempts",
+              "definition": "Lifetime count of incorrect-passcode attempts left before the share locks permanently. Decremented and persisted before responding, so parallel guesses cannot bypass the limit."
+            },
+            {
+              "id": "AssessmentShare.lastManifestAtMs",
+              "path": "AssessmentShare.lastManifestAtMs",
+              "min": 0,
+              "max": "1",
+              "type": [
+                {
+                  "code": "decimal"
+                }
+              ],
+              "short": "Last manifest poll (epoch ms)",
+              "definition": "Timestamp of the most recent manifest request, in milliseconds. Used to throttle frequent polling of one share (429 + Retry-After)."
+            },
+            {
+              "id": "AssessmentShare.fileTokens",
+              "path": "AssessmentShare.fileTokens",
+              "min": 0,
+              "max": "*",
+              "type": [
+                {
+                  "code": "BackboneElement"
+                }
+              ],
+              "short": "Short-lived file-location tokens",
+              "definition": "Tokens minted when the manifest returns a 'location' URL instead of embedding the payload. Each grants a short, time-bounded fetch of one specific ciphertext."
+            },
+            {
+              "id": "AssessmentShare.fileTokens.token",
+              "path": "AssessmentShare.fileTokens.token",
+              "min": 1,
+              "max": "1",
+              "type": [
+                {
+                  "code": "string"
+                }
+              ],
+              "short": "Opaque file token",
+              "definition": "The token value, of the form '<shareId>~<random>', embedded in the manifest's 'location' URL so the file endpoint can resolve the share without a custom search parameter."
+            },
+            {
+              "id": "AssessmentShare.fileTokens.expiresAtMs",
+              "path": "AssessmentShare.fileTokens.expiresAtMs",
+              "min": 1,
+              "max": "1",
+              "type": [
+                {
+                  "code": "decimal"
+                }
+              ],
+              "short": "Token expiry (epoch ms)",
+              "definition": "Absolute expiry of the file token in milliseconds. After it, fetching the location returns 410 Gone."
+            },
+            {
+              "id": "AssessmentShare.fileTokens.jwe",
+              "path": "AssessmentShare.fileTokens.jwe",
+              "min": 1,
+              "max": "1",
+              "type": [
+                {
+                  "code": "string"
+                }
+              ],
+              "short": "The ciphertext this token serves",
+              "definition": "The exact JWE the manifest advertised when it minted this token. Frozen per token because a 'location' fetch must return the bytes the manifest described, not a newer rebuild of the share."
+            },
+            {
+              "id": "AssessmentShare.accessLog",
+              "path": "AssessmentShare.accessLog",
+              "min": 0,
+              "max": "*",
+              "type": [
+                {
+                  "code": "BackboneElement"
+                }
+              ],
+              "short": "Recipient read history",
+              "definition": "One entry per resolved manifest poll, so the sharing organization can see when the recipient actually looked and how much was visible then \u2014 the accountability half of a time-bounded grant. Bounded to the most recent entries."
+            },
+            {
+              "id": "AssessmentShare.accessLog.atMs",
+              "path": "AssessmentShare.accessLog.atMs",
+              "min": 1,
+              "max": "1",
+              "type": [
+                {
+                  "code": "decimal"
+                }
+              ],
+              "short": "Read time (epoch ms)",
+              "definition": "When the recipient resolved the manifest."
+            },
+            {
+              "id": "AssessmentShare.accessLog.recipient",
+              "path": "AssessmentShare.accessLog.recipient",
+              "min": 0,
+              "max": "1",
+              "type": [
+                {
+                  "code": "string"
+                }
+              ],
+              "short": "Self-declared recipient",
+              "definition": "The 'recipient' string the receiver sent in the manifest request body, per the SHL spec. Self-declared, so it is a record of what was claimed rather than a verified identity."
+            },
+            {
+              "id": "AssessmentShare.accessLog.responseCount",
+              "path": "AssessmentShare.accessLog.responseCount",
+              "min": 0,
+              "max": "1",
+              "type": [
+                {
+                  "code": "integer"
+                }
+              ],
+              "short": "Assessments visible at that read",
+              "definition": "How many QuestionnaireResponses the share exposed at that moment. Grows over time as the sharing organization completes more assessments."
+            }
+          ]
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "StructureDefinition/AssessmentShare"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "App",
+        "id": "share-app",
+        "type": "app",
+        "apiVersion": 1,
+        "endpoint": {
+          "type": "http-rpc",
+          "url": "http://share-app:3000/share-app",
+          "secret": "share-app-secret"
+        },
+        "operations": {
+          "share-create": {
+            "method": "POST",
+            "path": [
+              "share-app",
+              "shares",
+              "$create"
+            ]
+          },
+          "share-revoke": {
+            "method": "POST",
+            "path": [
+              "share-app",
+              "shares",
+              {
+                "name": "shareId"
+              },
+              "$revoke"
+            ]
+          },
+          "share-manifest": {
+            "method": "POST",
+            "path": [
+              "share-app",
+              "manifest",
+              {
+                "name": "shareId"
+              }
+            ],
+            "policies": {
+              "share-manifest-public": {
+                "engine": "allow"
+              }
+            }
+          },
+          "share-file": {
+            "method": "GET",
+            "path": [
+              "share-app",
+              "file",
+              {
+                "name": "fileId"
+              }
+            ],
+            "policies": {
+              "share-file-public": {
+                "engine": "allow"
+              }
+            }
+          }
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "App/share-app"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "id": "provider-a",
+        "name": "Northside Behavioral Health",
+        "active": true
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/provider-a"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "id": "provider-b",
+        "name": "Riverside Psychiatry Group",
+        "active": true
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/provider-b"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "patient-jane-roe",
+        "name": [
+          {
+            "given": [
+              "Jane"
+            ],
+            "family": "Roe"
+          }
+        ],
+        "gender": "female",
+        "birthDate": "1988-04-12",
+        "managingOrganization": {
+          "reference": "Organization/provider-a"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/patient-jane-roe"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "CodeSystem",
+        "id": "gad7-frequency",
+        "url": "http://example.org/fhir/CodeSystem/gad7-frequency",
+        "name": "GAD7Frequency",
+        "title": "GAD-7 answer scales",
+        "status": "active",
+        "content": "complete",
+        "caseSensitive": true,
+        "concept": [
+          {
+            "code": "not-at-all",
+            "display": "Not at all"
+          },
+          {
+            "code": "several-days",
+            "display": "Several days"
+          },
+          {
+            "code": "more-than-half",
+            "display": "More than half the days"
+          },
+          {
+            "code": "nearly-every-day",
+            "display": "Nearly every day"
+          },
+          {
+            "code": "not-difficult",
+            "display": "Not difficult at all"
+          },
+          {
+            "code": "somewhat-difficult",
+            "display": "Somewhat difficult"
+          },
+          {
+            "code": "very-difficult",
+            "display": "Very difficult"
+          },
+          {
+            "code": "extremely-difficult",
+            "display": "Extremely difficult"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "CodeSystem/gad7-frequency"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "ValueSet",
+        "id": "gad7-frequency",
+        "url": "http://example.org/fhir/ValueSet/gad7-frequency",
+        "name": "GAD7FrequencyVS",
+        "status": "active",
+        "compose": {
+          "include": [
+            {
+              "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+              "concept": [
+                {
+                  "code": "not-at-all",
+                  "display": "Not at all"
+                },
+                {
+                  "code": "several-days",
+                  "display": "Several days"
+                },
+                {
+                  "code": "more-than-half",
+                  "display": "More than half the days"
+                },
+                {
+                  "code": "nearly-every-day",
+                  "display": "Nearly every day"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "ValueSet/gad7-frequency"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "ValueSet",
+        "id": "gad7-difficulty",
+        "url": "http://example.org/fhir/ValueSet/gad7-difficulty",
+        "name": "GAD7DifficultyVS",
+        "status": "active",
+        "compose": {
+          "include": [
+            {
+              "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+              "concept": [
+                {
+                  "code": "not-difficult",
+                  "display": "Not difficult at all"
+                },
+                {
+                  "code": "somewhat-difficult",
+                  "display": "Somewhat difficult"
+                },
+                {
+                  "code": "very-difficult",
+                  "display": "Very difficult"
+                },
+                {
+                  "code": "extremely-difficult",
+                  "display": "Extremely difficult"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "ValueSet/gad7-difficulty"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Questionnaire",
+        "id": "gad7",
+        "url": "http://example.org/fhir/Questionnaire/gad7",
+        "name": "GAD7",
+        "title": "GAD-7 (Generalized Anxiety Disorder 7-item scale)",
+        "status": "active",
+        "subjectType": [
+          "Patient"
+        ],
+        "description": "Over the last 2 weeks, how often have you been bothered by the following problems?",
+        "item": [
+          {
+            "linkId": "gad7-q1",
+            "text": "Feeling nervous, anxious, or on edge",
+            "type": "choice",
+            "required": true,
+            "answerOption": [
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "not-at-all",
+                  "display": "Not at all"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "several-days",
+                  "display": "Several days"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "more-than-half",
+                  "display": "More than half the days"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "nearly-every-day",
+                  "display": "Nearly every day"
+                }
+              }
+            ]
+          },
+          {
+            "linkId": "gad7-q2",
+            "text": "Not being able to stop or control worrying",
+            "type": "choice",
+            "required": true,
+            "answerOption": [
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "not-at-all",
+                  "display": "Not at all"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "several-days",
+                  "display": "Several days"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "more-than-half",
+                  "display": "More than half the days"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "nearly-every-day",
+                  "display": "Nearly every day"
+                }
+              }
+            ]
+          },
+          {
+            "linkId": "gad7-q3",
+            "text": "Worrying too much about different things",
+            "type": "choice",
+            "required": true,
+            "answerOption": [
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "not-at-all",
+                  "display": "Not at all"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "several-days",
+                  "display": "Several days"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "more-than-half",
+                  "display": "More than half the days"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "nearly-every-day",
+                  "display": "Nearly every day"
+                }
+              }
+            ]
+          },
+          {
+            "linkId": "gad7-q4",
+            "text": "Trouble relaxing",
+            "type": "choice",
+            "required": true,
+            "answerOption": [
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "not-at-all",
+                  "display": "Not at all"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "several-days",
+                  "display": "Several days"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "more-than-half",
+                  "display": "More than half the days"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "nearly-every-day",
+                  "display": "Nearly every day"
+                }
+              }
+            ]
+          },
+          {
+            "linkId": "gad7-q5",
+            "text": "Being so restless that it's hard to sit still",
+            "type": "choice",
+            "required": true,
+            "answerOption": [
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "not-at-all",
+                  "display": "Not at all"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "several-days",
+                  "display": "Several days"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "more-than-half",
+                  "display": "More than half the days"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "nearly-every-day",
+                  "display": "Nearly every day"
+                }
+              }
+            ]
+          },
+          {
+            "linkId": "gad7-q6",
+            "text": "Becoming easily annoyed or irritable",
+            "type": "choice",
+            "required": true,
+            "answerOption": [
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "not-at-all",
+                  "display": "Not at all"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "several-days",
+                  "display": "Several days"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "more-than-half",
+                  "display": "More than half the days"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "nearly-every-day",
+                  "display": "Nearly every day"
+                }
+              }
+            ]
+          },
+          {
+            "linkId": "gad7-q7",
+            "text": "Feeling afraid as if something awful might happen",
+            "type": "choice",
+            "required": true,
+            "answerOption": [
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "not-at-all",
+                  "display": "Not at all"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "several-days",
+                  "display": "Several days"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "more-than-half",
+                  "display": "More than half the days"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "nearly-every-day",
+                  "display": "Nearly every day"
+                }
+              }
+            ]
+          },
+          {
+            "linkId": "gad7-q8",
+            "text": "How difficult have these problems made it for you to do your work, take care of things at home, or get along with other people?",
+            "type": "choice",
+            "required": false,
+            "answerOption": [
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "not-difficult",
+                  "display": "Not difficult at all"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "somewhat-difficult",
+                  "display": "Somewhat difficult"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "very-difficult",
+                  "display": "Very difficult"
+                }
+              },
+              {
+                "valueCoding": {
+                  "system": "http://example.org/fhir/CodeSystem/gad7-frequency",
+                  "code": "extremely-difficult",
+                  "display": "Extremely difficult"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Questionnaire/gad7"
+      }
+    }
+  ]
+}

--- a/aidbox-integrations/shared-assessment-link/package.json
+++ b/aidbox-integrations/shared-assessment-link/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "aidbox-shared-assessment-link",
+  "version": "1.0.0",
+  "description": "Time-bounded, field-redacted assessment sharing between provider organizations over SMART Health Links, integrated with Aidbox",
+  "module": "src/server.ts",
+  "type": "module",
+  "scripts": {
+    "dev": "bun --watch src/server.ts",
+    "start": "bun src/server.ts",
+    "lint": "eslint src/**/*.ts --fix"
+  },
+  "keywords": [
+    "fhir",
+    "smart-health-links",
+    "aidbox",
+    "questionnaire",
+    "gad-7",
+    "jwe",
+    "typescript",
+    "bun"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@formbox/hs-theme": "^0.4.1",
+    "@formbox/renderer": "^0.4.1",
+    "@health-samurai/aidbox-client": "^0.0.0-alpha.4",
+    "@lhncbc/ucum-lhc": "^7.1.9",
+    "classnames": "^2.5.1",
+    "fhirpath": "^4.6.0",
+    "jose": "^5.2.0",
+    "mobx": "^6.16.1",
+    "mobx-react-lite": "^4.1.1",
+    "mobx-utils": "^6.1.1",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.1.0",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@typescript-eslint/eslint-plugin": "^6.20.0",
+    "@typescript-eslint/parser": "^6.20.0",
+    "eslint": "^8.56.0",
+    "prettier": "^3.2.5",
+    "typescript": "^5.3.3"
+  }
+}

--- a/aidbox-integrations/shared-assessment-link/src/app.html
+++ b/aidbox-integrations/shared-assessment-link/src/app.html
@@ -1,0 +1,1194 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Shared Assessment Link</title>
+<!-- Stylesheet for @formbox/hs-theme, which renders the GAD-7 intake form. -->
+<link rel="stylesheet" href="/assets/intake.css" />
+<style>
+  /*
+   * Palette taken from @formbox/hs-theme, which renders the GAD-7 form on the
+   * intake tab — so the form reads as part of the page rather than a foreign
+   * white box dropped into it. Slate-biased neutrals, not pure greys.
+   *
+   * The accent carries meaning here: it marks what happens *in your browser*
+   * (decryption, the key) as opposed to --server for what the backend does. On
+   * a light ground the original mint fell far below AA, so that role moves to
+   * the theme's blue, darkened for contrast on white.
+   */
+  :root {
+    --ground: #f7fafc;   /* page */
+    --panel: #ffffff;    /* cards */
+    --panel-2: #edf2f7;  /* insets, callouts */
+    --line: #cbd5e0;
+    --text: #1a202c;
+    --muted: #5a6b82;    /* slate-biased grey — AA on both panel and ground */
+    --accent: #2b6cb0;   /* unlocked / open / runs in the browser */
+    --server: #6b46c1;   /* runs on the server (Aidbox + backend) */
+    --locked: #b45309;   /* locked / withheld / pending */
+    --danger: #c53030;
+    /* Text that sits on an --accent fill (buttons, the selected tab). */
+    --on-accent: #ffffff;
+    /* Tinted washes for status surfaces, kept faint so text stays the signal. */
+    --accent-wash: #ebf4fb;
+    --locked-wash: #fdf6ec;
+    --danger-wash: #fdeded;
+    --mono: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+    --sans: "Inter", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    --display: "Space Grotesk", var(--sans);
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--ground);
+    color: var(--text);
+    font-family: var(--sans);
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap { max-width: 860px; margin: 0 auto; padding: 48px 24px 96px; }
+
+  /* ---- header ---- */
+  header { margin-bottom: 32px; }
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: 12px; letter-spacing: .22em; text-transform: uppercase;
+    color: var(--accent); margin: 0 0 12px;
+  }
+  h1 {
+    font-family: var(--display); font-weight: 600;
+    font-size: clamp(26px, 5vw, 38px); letter-spacing: -.02em; margin: 0 0 8px;
+  }
+  .sub { color: var(--muted); margin: 0; max-width: 62ch; }
+
+  /* ---- role tabs ---- */
+  .roles { display: flex; gap: 6px; margin-bottom: 22px; flex-wrap: wrap; }
+  .role {
+    background: transparent; color: var(--muted);
+    border: 1px solid var(--line); border-radius: 10px;
+    padding: 10px 16px; font-size: 13px; font-weight: 500;
+    font-family: var(--sans); cursor: pointer;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .role:hover { color: var(--text); }
+  .role[aria-selected="true"] { color: var(--on-accent); background: var(--accent); border-color: var(--accent); }
+  .role .num { font-family: var(--mono); font-size: 11px; opacity: .7; }
+  .role[aria-selected="true"] .num { opacity: .55; }
+
+  /* ---- cards ---- */
+  .card {
+    background: var(--panel); border: 1px solid var(--line);
+    border-radius: 14px; padding: 22px;
+  }
+  .card + .card { margin-top: 16px; }
+  .card h2 {
+    font-family: var(--display); font-weight: 600; font-size: 17px; margin: 0 0 4px;
+  }
+  .card .hint { color: var(--muted); font-size: 13px; margin: 0 0 18px; }
+  .card .hint:last-child { margin-bottom: 0; }
+  .card .hint code { font-family: var(--mono); color: var(--text); font-size: 12.5px; }
+
+  .org-line {
+    font-family: var(--mono); font-size: 11px; letter-spacing: .1em;
+    text-transform: uppercase; color: var(--muted); margin: 0 0 14px;
+  }
+  .org-line b {
+    color: var(--text); font-weight: 500; letter-spacing: normal;
+    text-transform: none; font-size: 13px;
+  }
+
+  /* ---- fields ---- */
+  label.fld {
+    display: block; font-family: var(--mono);
+    font-size: 11px; letter-spacing: .14em; text-transform: uppercase;
+    color: var(--muted); margin-bottom: 8px;
+  }
+  label.fld .opt { text-transform: none; letter-spacing: 0; opacity: .7; }
+  input[type=text], input[type=datetime-local], select, textarea {
+    width: 100%; background: var(--ground); color: var(--text);
+    border: 1px solid var(--line); border-radius: 10px;
+    padding: 11px 13px; font-family: var(--mono); font-size: 13px;
+  }
+  textarea { min-height: 84px; resize: vertical; line-height: 1.5; word-break: break-all; }
+  input:focus-visible, select:focus-visible, textarea:focus-visible {
+    outline: 2px solid var(--accent); outline-offset: 1px;
+  }
+  .preset-label {
+    font-family: var(--mono); font-size: 11px; letter-spacing: .14em;
+    text-transform: uppercase; color: var(--muted);
+  }
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+  @media (max-width: 620px) { .grid2 { grid-template-columns: 1fr; } }
+  .field + .field, .grid2 + .field, .field + .grid2, .grid2 + .grid2 { margin-top: 16px; }
+
+  .row { display: flex; gap: 12px; align-items: center; margin-top: 18px; flex-wrap: wrap; }
+  button {
+    font-family: var(--sans); font-weight: 600; font-size: 14px;
+    color: var(--on-accent); background: var(--accent);
+    border: 0; border-radius: 10px; padding: 11px 20px; cursor: pointer;
+    transition: transform .08s ease, filter .15s ease;
+  }
+  button:hover { filter: brightness(1.08); }
+  button:active { transform: translateY(1px); }
+  button:disabled { opacity: .45; cursor: not-allowed; }
+  button:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
+  button.ghost { background: transparent; color: var(--muted); border: 1px solid var(--line); }
+  button.ghost:hover { color: var(--text); }
+  button.small { padding: 7px 14px; font-size: 13px; }
+  button.danger { background: transparent; color: var(--danger); border: 1px solid var(--danger); }
+
+  /* ---- GAD-7 intake form (rendered by @formbox/hs-theme) ---- */
+  /*
+   * The page palette is drawn from this theme, so the form now sits flush on the
+   * card instead of needing its own inset surface. Only the busy state is ours.
+   */
+  .formbox-wrap { margin-top: 18px; }
+  .formbox-wrap[aria-busy="true"] { opacity: .55; pointer-events: none; }
+  #gad7-root .field { margin-bottom: 4px; }
+
+  /* ---- checkbox lists (item redaction) ---- */
+  .checks { display: grid; gap: 8px; }
+  .check {
+    display: flex; align-items: flex-start; gap: 11px;
+    border: 1px solid var(--line); border-radius: 10px;
+    padding: 11px 13px; cursor: pointer; background: var(--ground);
+    transition: all .12s ease;
+  }
+  .check:hover { border-color: var(--muted); }
+  .check input { margin: 3px 0 0; accent-color: var(--locked); flex: 0 0 auto; }
+  .check-body { font-size: 13.5px; }
+  .check-id { font-family: var(--mono); font-size: 11px; color: var(--muted); display: block; margin-top: 3px; }
+  .check.on { border-color: var(--locked); background: var(--locked-wash); }
+  .check.on .check-body { color: var(--locked); }
+
+  .toggle-row {
+    display: flex; align-items: flex-start; gap: 11px; margin-top: 16px;
+    border: 1px solid var(--line); border-radius: 10px; padding: 13px;
+    background: var(--ground);
+  }
+  .toggle-row input { accent-color: var(--accent); margin: 3px 0 0; flex: 0 0 auto; }
+  .toggle-row label { font-size: 13.5px; cursor: pointer; }
+  .toggle-row .why { color: var(--muted); font-size: 12.5px; display: block; margin-top: 4px; }
+
+  /* ---- link box ---- */
+  .linkbox {
+    margin-top: 18px; background: var(--panel-2);
+    border: 1px solid var(--line); border-radius: 12px; padding: 16px;
+  }
+  .linkbox-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing: .14em;
+    text-transform: uppercase; color: var(--muted); display: block; margin-bottom: 10px;
+  }
+  .linkbox code {
+    display: block; font-family: var(--mono); font-size: 12px;
+    color: var(--accent); word-break: break-all; line-height: 1.55;
+    max-height: 96px; overflow: auto;
+  }
+  .linkbox .row { margin-top: 12px; }
+
+  /* ---- share list (dashboard) ---- */
+  .shares { display: grid; gap: 12px; }
+  .share {
+    border: 1px solid var(--line); border-radius: 12px;
+    padding: 16px; background: var(--ground);
+  }
+  .share-head { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+  .share-title { font-family: var(--display); font-weight: 600; font-size: 15px; }
+  .share-meta {
+    font-family: var(--mono); font-size: 11.5px; color: var(--muted);
+    margin-top: 10px; display: grid; gap: 4px;
+  }
+  .share-meta b { color: var(--text); font-weight: 400; }
+  .share .row { margin-top: 13px; }
+
+  .badge {
+    font-family: var(--mono); font-size: 10px; letter-spacing: .12em;
+    text-transform: uppercase; border-radius: 999px; padding: 3px 9px;
+    border: 1px solid currentColor; white-space: nowrap;
+  }
+  .badge.open { color: var(--accent); }
+  .badge.ended, .badge.revoked { color: var(--danger); }
+  .badge.pending { color: var(--locked); }
+
+  /* ---- recipient viewer ---- */
+  .reveal { margin-top: 18px; }
+  .reveal-head {
+    display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 14px;
+  }
+  .reveal-head h2 { margin: 0; font-family: var(--display); font-weight: 600; font-size: 17px; }
+  .window-note {
+    background: var(--panel-2); border: 1px solid var(--line);
+    border-left: 3px solid var(--accent); border-radius: 8px;
+    padding: 13px 15px; font-size: 13px; color: var(--muted); margin-bottom: 16px;
+  }
+  .window-note.closed { border-left-color: var(--danger); }
+  .window-note b { color: var(--text); font-weight: 500; }
+
+  .resp {
+    border: 1px solid var(--line); border-radius: 12px;
+    padding: 16px; background: var(--ground); margin-bottom: 12px;
+  }
+  .resp-head { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; margin-bottom: 12px; }
+  .resp-date { font-family: var(--mono); font-size: 12px; color: var(--muted); }
+  .resp-score { margin-left: auto; text-align: right; }
+  .resp-score .n { font-family: var(--display); font-size: 22px; font-weight: 600; }
+  .resp-score .b { font-family: var(--mono); font-size: 11px; color: var(--muted); display: block; }
+  .resp-score.withheld .n { color: var(--locked); font-size: 14px; font-family: var(--mono); }
+
+  .answers { display: grid; gap: 1px; background: var(--line); border-radius: 8px; overflow: hidden; }
+  .ans {
+    display: flex; gap: 12px; align-items: baseline;
+    background: var(--panel); padding: 9px 12px; font-size: 13px;
+  }
+  .ans-q { flex: 1; }
+  .ans-v { font-family: var(--mono); font-size: 12px; color: var(--accent); text-align: right; flex: 0 0 auto; }
+  .ans.masked { background: var(--locked-wash); }
+  .ans.masked .ans-q { color: var(--muted); }
+  .ans.masked .ans-v { color: var(--locked); }
+
+  /* ---- behind the scenes ---- */
+  .bts-toggle {
+    background: transparent; color: var(--muted); border: 0;
+    font-family: var(--mono); font-size: 11px; letter-spacing: .14em;
+    text-transform: uppercase; padding: 0; margin-top: 32px; cursor: pointer;
+    display: flex; align-items: center; gap: 7px;
+  }
+  .bts-toggle:hover { color: var(--text); filter: none; }
+  .bts-chev { transition: transform .15s ease; display: inline-block; }
+  .bts-toggle[aria-expanded="true"] .bts-chev { transform: rotate(90deg); }
+  .bts { margin-top: 16px; }
+  .steps { list-style: none; padding: 0; margin: 0; display: grid; gap: 8px; }
+  .step { border: 1px solid var(--line); border-radius: 10px; background: var(--panel); overflow: hidden; }
+  .step-head {
+    display: flex; align-items: center; gap: 11px;
+    padding: 12px 14px; cursor: pointer; width: 100%;
+    background: transparent; border: 0; color: inherit;
+    font-family: var(--sans); font-size: 13.5px; font-weight: 400; text-align: left;
+  }
+  .step-head:hover { filter: none; }
+  .step-dot { width: 7px; height: 7px; border-radius: 50%; flex: 0 0 auto; background: var(--line); }
+  .step.done .step-dot { background: var(--accent); }
+  .step.active .step-dot { background: var(--locked); }
+  .step.fail .step-dot { background: var(--danger); }
+  .step-where {
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: .1em;
+    text-transform: uppercase; margin-left: auto; padding: 2px 7px;
+    border-radius: 4px; border: 1px solid currentColor; white-space: nowrap;
+  }
+  .step-where.browser { color: var(--accent); }
+  .step-where.server { color: var(--server); }
+  .step-body {
+    padding: 12px 14px 14px 32px; font-family: var(--mono); font-size: 11.5px;
+    color: var(--muted); white-space: pre-wrap; word-break: break-all;
+    border-top: 1px solid var(--line);
+    /* Raw HTTP and ciphertext — an inset surface separates it from the label. */
+    background: var(--ground);
+  }
+  .step-body.hidden { display: none; }
+  .step-body .lbl { color: var(--text); display: block; margin: 9px 0 3px; }
+  .step-body .lbl:first-child { margin-top: 0; }
+
+  /* ---- misc ---- */
+  .hidden { display: none !important; }
+  .err {
+    border: 1px solid var(--danger); background: var(--danger-wash);
+    border-radius: 10px; padding: 13px 15px; font-size: 13px;
+    color: var(--danger); margin-top: 16px;
+  }
+  .ok-note {
+    border: 1px solid var(--accent); background: var(--accent-wash);
+    border-radius: 10px; padding: 13px 15px; font-size: 13px;
+    color: var(--accent); margin-top: 16px;
+  }
+  .empty { color: var(--muted); font-size: 13px; font-family: var(--mono); }
+  footer { margin-top: 48px; color: var(--muted); font-size: 12px; font-family: var(--mono); }
+  footer a { color: var(--accent); }
+  footer code { color: var(--text); }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <p class="eyebrow">SMART Health Link · Assessment sharing</p>
+      <h1>Share assessments, on your terms</h1>
+      <p class="sub">
+        One provider organization shares a patient's GAD-7 history with another — for a fixed
+        window, with chosen questions held back. Both are enforced on every read, so newly
+        completed assessments appear automatically and closing the share takes effect at once.
+      </p>
+    </header>
+
+    <div class="roles" role="tablist">
+      <button class="role" id="role-intake" role="tab" aria-selected="true">
+        <span class="num">1</span> Complete a GAD-7
+      </button>
+      <button class="role" id="role-share" role="tab" aria-selected="false">
+        <span class="num">2</span> Share it
+      </button>
+      <button class="role" id="role-manage" role="tab" aria-selected="false">
+        <span class="num">3</span> Manage shares
+      </button>
+      <button class="role" id="role-receive" role="tab" aria-selected="false">
+        <span class="num">4</span> Open a link
+      </button>
+    </div>
+
+    <!-- ============ 1. INTAKE ============ -->
+    <section id="pane-intake">
+      <div class="card">
+        <p class="org-line">Acting as <b>Northside Behavioral Health</b> · the sharing organization</p>
+        <h2>GAD-7 questionnaire</h2>
+        <p class="hint">Over the last 2 weeks, how often have you been bothered by the following problems?</p>
+
+        <!--
+          Rendered by @formbox/renderer from the FHIR Questionnaire stored in
+          Aidbox — the same renderer HealthSamurai/phr uses. It mounts the patient
+          picker, the form and its submit button, so the instrument is defined
+          once in FHIR rather than duplicated in this page.
+        -->
+        <div id="gad7-root"></div>
+      </div>
+
+      <div class="card">
+        <h2>Assessments on file</h2>
+        <p class="hint">
+          Everything this organization has recorded for the selected patient. A share covers all
+          of these — and anything added later.
+        </p>
+        <div id="intake-history"></div>
+      </div>
+    </section>
+
+    <!-- ============ 2. SHARE ============ -->
+    <section id="pane-share" class="hidden">
+      <div class="card">
+        <p class="org-line">Acting as <b>Northside Behavioral Health</b> · granting access</p>
+        <h2>Grant access to another organization</h2>
+        <p class="hint">
+          Pick the patient, the window, and what stays private. You get back a link to hand to
+          the receiving organization.
+        </p>
+
+        <div class="field">
+          <label class="fld" for="share-patient">Patient</label>
+          <select id="share-patient"></select>
+        </div>
+
+        <div class="grid2">
+          <div>
+            <label class="fld" for="share-recipient">Receiving organization</label>
+            <select id="share-recipient">
+              <option value="Organization/provider-b|Riverside Psychiatry Group">Riverside Psychiatry Group</option>
+            </select>
+          </div>
+          <div>
+            <label class="fld" for="share-passcode">Passcode <span class="opt">(optional, sent separately)</span></label>
+            <input type="text" id="share-passcode" placeholder="e.g. 4821" autocomplete="off" />
+          </div>
+        </div>
+
+        <div class="grid2">
+          <div>
+            <label class="fld" for="share-start">Access starts</label>
+            <input type="datetime-local" id="share-start" />
+          </div>
+          <div>
+            <label class="fld" for="share-end">Access ends</label>
+            <input type="datetime-local" id="share-end" />
+          </div>
+        </div>
+        <div class="row" style="margin-top:12px">
+          <span class="preset-label">Window</span>
+          <button class="ghost small" data-window="2" type="button">2 min</button>
+          <button class="ghost small" data-window="1440" type="button">1 day</button>
+          <button class="ghost small" data-window="43200" type="button">30 days</button>
+          <button class="ghost small" data-window="129600" type="button">90 days</button>
+        </div>
+        <p class="hint" style="margin-top:12px;margin-bottom:0">
+          On the end date the link closes on its own — nothing to follow up on. Pick
+          <b>2 min</b> to watch that happen.
+        </p>
+      </div>
+
+      <div class="card">
+        <h2>Hold back specific questions</h2>
+        <p class="hint">
+          Tick anything the receiving organization should not see. The question still appears on
+          their side marked as withheld, so they can tell a held-back answer from an unanswered one.
+        </p>
+        <div class="checks" id="hide-items"></div>
+
+        <div class="toggle-row">
+          <input type="checkbox" id="share-score" checked />
+          <label for="share-score">
+            Share the total score
+            <span class="why">
+              The total is the sum of the seven scored questions, so sending it next to a
+              held-back question can give that answer away. Left on, the score is recalculated
+              from only what's visible; turned off, no score is sent at all.
+            </span>
+          </label>
+        </div>
+
+        <div class="row">
+          <button id="create-share" type="button">Create share link</button>
+        </div>
+        <div id="share-msg"></div>
+
+        <div class="linkbox hidden" id="share-linkbox">
+          <span class="linkbox-label">SMART Health Link for the receiving organization</span>
+          <code id="share-link"></code>
+          <div class="row">
+            <button class="ghost small" id="copy-link" type="button">Copy</button>
+            <button class="ghost small" id="open-link" type="button">Open as the recipient</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ 3. MANAGE ============ -->
+    <section id="pane-manage" class="hidden">
+      <div class="card">
+        <p class="org-line">Acting as <b>Northside Behavioral Health</b> · managing grants</p>
+        <h2>Shares you've granted</h2>
+        <p class="hint">
+          Each grant, its window, what it holds back, and when the recipient actually read it.
+          Closing one takes effect immediately.
+        </p>
+        <div class="row" style="margin-top:0">
+          <button class="ghost small" id="refresh-shares" type="button">Refresh</button>
+        </div>
+        <div class="shares" id="shares-list" style="margin-top:16px"></div>
+      </div>
+    </section>
+
+    <!-- ============ 4. RECEIVE ============ -->
+    <section id="pane-receive" class="hidden">
+      <div class="card">
+        <p class="org-line">Acting as <b>Riverside Psychiatry Group</b> · the receiving organization</p>
+        <h2>Open a shared link</h2>
+        <p class="hint">
+          Paste the <code>shlink:</code> you were given. This page resolves it and decrypts the
+          contents locally — the key never leaves your browser.
+        </p>
+
+        <div class="field">
+          <label class="fld" for="shl-input">SMART Health Link</label>
+          <textarea id="shl-input" placeholder="shlink:/eyJ1cmwiOiJodHRwOi8v..." spellcheck="false"></textarea>
+        </div>
+
+        <div class="grid2">
+          <div>
+            <label class="fld" for="recv-passcode">Passcode <span class="opt">(if the link is locked)</span></label>
+            <input type="text" id="recv-passcode" autocomplete="off" />
+          </div>
+          <div>
+            <label class="fld" for="recv-recipient">Recipient (you)</label>
+            <input type="text" id="recv-recipient" value="Riverside Psychiatry Group" />
+          </div>
+        </div>
+
+        <div class="row">
+          <button id="resolve-link" type="button">Open link</button>
+          <button id="clear-link" class="ghost" type="button">Clear</button>
+        </div>
+        <div id="recv-msg"></div>
+      </div>
+
+      <div class="reveal hidden" id="reveal">
+        <div class="window-note" id="window-note"></div>
+        <div class="reveal-head">
+          <h2>Shared assessments</h2>
+          <span class="badge open" id="reveal-badge">open</span>
+        </div>
+        <div id="responses"></div>
+      </div>
+
+      <button class="bts-toggle hidden" id="bts-toggle" type="button" aria-expanded="false">
+        Behind the scenes <span class="bts-chev" aria-hidden="true">›</span>
+      </button>
+      <div class="bts hidden" id="bts">
+        <ol class="steps" id="steps"></ol>
+      </div>
+    </section>
+
+    <footer>
+      GAD-7 responses stored as FHIR <code>QuestionnaireResponse</code> in Aidbox · shared over
+      <a href="https://hl7.org/fhir/uv/smart-health-cards-and-links/STU1/links-specification.html">SMART Health Links</a>
+    </footer>
+  </div>
+
+<script type="module">
+/* ------------------------------------------------------------------------- *
+ * Shared assessment link — demo UI
+ *
+ * Four roles on one page:
+ *   1. intake   — the sharing organization records a GAD-7
+ *   2. share    — it grants another organization a time-bounded, redacted view
+ *   3. manage   — it reviews and closes its grants
+ *   4. receive  — the other organization resolves the link and decrypts locally
+ *
+ * Roles 1–3 call this app's demo routes; in production those are the
+ * authenticated `share-create` / `share-revoke` Aidbox operations inside the
+ * sharing organization's own system. Role 4 calls only the public SHL endpoints,
+ * exactly as any conformant receiver would.
+ * ------------------------------------------------------------------------- */
+
+const $ = (id) => document.getElementById(id);
+
+/*
+ * The wire contract comes from GET /demo/extensions, so the extension URLs the
+ * viewer interprets are defined once — on the server — rather than re-declared
+ * here where they could drift. (The intake form is a separate React island that
+ * fetches the Questionnaire itself; see src/forms/intake.tsx.)
+ */
+let SCORE_EXT = '';         // extension carrying the total score
+let MASKED_EXT = '';        // marks an item the sender withheld
+let WINDOW_EXT = '';        // describes the sharing window on the bundle
+let SCORED_LINK_IDS = [];   // items that feed the 0–21 total
+
+function severity(total) {
+  if (total >= 15) return 'Severe anxiety';
+  if (total >= 10) return 'Moderate anxiety';
+  if (total >= 5) return 'Mild anxiety';
+  return 'Minimal anxiety';
+}
+
+function fmtDate(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric',
+  });
+}
+function fmtDateTime(ms) {
+  return new Date(ms).toLocaleString(undefined, {
+    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+  });
+}
+function esc(s) {
+  return String(s ?? '').replace(/[&<>"']/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]);
+}
+function notice(el, text, kind = 'err') {
+  el.innerHTML = `<div class="${kind === 'err' ? 'err' : 'ok-note'}">${esc(text)}</div>`;
+}
+function clearNotice(el) { el.innerHTML = ''; }
+
+/* ---------------------- role switching ---------------------- */
+
+const ROLES = ['intake', 'share', 'manage', 'receive'];
+function showRole(name) {
+  for (const r of ROLES) {
+    $(`role-${r}`).setAttribute('aria-selected', String(r === name));
+    $(`pane-${r}`).classList.toggle('hidden', r !== name);
+  }
+  if (name === 'manage') loadShares();
+  if (name === 'share') seedWindowDefaults();
+}
+for (const r of ROLES) $(`role-${r}`).addEventListener('click', () => showRole(r));
+
+/* ---------------------- 1. intake ---------------------- */
+
+async function loadFormContract() {
+  const res = await fetch('/demo/extensions');
+  const c = await res.json();
+  SCORE_EXT = c.score;
+  MASKED_EXT = c.masked;
+  WINDOW_EXT = c.window;
+  SCORED_LINK_IDS = c.scoredLinkIds;
+}
+
+/*
+ * The intake form itself is rendered by @formbox/renderer in a React island
+ * (src/forms/intake.tsx) mounted at #gad7-root. It owns its own patient picker
+ * and submit button, and tells us when it saved so the history list refreshes.
+ */
+window.addEventListener('assessment-saved', () => loadHistory());
+
+async function loadHistory() {
+  // The React island owns the intake patient picker, so the history follows the
+  // share tab's selector — the same patient list, and the one that matters when
+  // deciding what to share.
+  const patient = $('share-patient').value;
+  if (!patient) return;
+  const res = await fetch(`/demo/assessments?patient=${encodeURIComponent(patient)}`);
+  const list = await res.json();
+  if (!Array.isArray(list) || list.length === 0) {
+    $('intake-history').innerHTML = '<p class="empty">No assessments recorded yet.</p>';
+    return;
+  }
+  $('intake-history').innerHTML = list.slice().reverse().map((r) => `
+    <div class="resp">
+      <div class="resp-head">
+        <span class="resp-date">${esc(fmtDate(r.authored))}</span>
+        <span class="resp-score">
+          <span class="n">${esc(r.total)}</span><span class="score-max">/21</span>
+          <span class="b">${esc(severity(r.total))}</span>
+        </span>
+      </div>
+    </div>`).join('');
+}
+
+/* ---------------------- 2. share ---------------------- */
+
+/**
+ * The redaction checkboxes, one per questionnaire item.
+ *
+ * Built from the same FHIR Questionnaire the renderer uses, so what Provider A
+ * can hide always matches what the form actually asks — a new item on the
+ * instrument shows up here without a code change.
+ */
+async function renderHideItems() {
+  const res = await fetch('/demo/intake-form');
+  const { questionnaire } = await res.json();
+  const items = questionnaire.item ?? [];
+
+  $('hide-items').innerHTML = items.map((item, i) => {
+    // The server says which items feed the total, so A can see that hiding an
+    // unscored one doesn't move the score.
+    const scored = SCORED_LINK_IDS.includes(item.linkId);
+    return `
+    <label class="check">
+      <input type="checkbox" value="${esc(item.linkId)}" />
+      <span class="check-body">${i + 1}. ${esc(item.text ?? item.linkId)}
+        <span class="check-id">${esc(item.linkId)}${scored ? '' : ' · not scored'}</span>
+      </span>
+    </label>`;
+  }).join('');
+
+  $('hide-items').addEventListener('change', (e) => {
+    const label = e.target.closest('.check');
+    if (label) label.classList.toggle('on', e.target.checked);
+  });
+}
+
+function hiddenItems() {
+  return [...document.querySelectorAll('#hide-items input:checked')].map((el) => el.value);
+}
+
+function toLocalInput(date) {
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function seedWindowDefaults() {
+  if ($('share-start').value) return;
+  setWindow(30 * 1440);
+}
+
+/** Set the window to start now and run for `minutes`. */
+function setWindow(minutes) {
+  const now = new Date();
+  $('share-start').value = toLocalInput(now);
+  $('share-end').value = toLocalInput(new Date(now.getTime() + minutes * 60_000));
+  clearNotice($('share-msg'));
+}
+
+for (const btn of document.querySelectorAll('[data-window]')) {
+  btn.addEventListener('click', () => setWindow(Number(btn.dataset.window)));
+}
+
+$('create-share').addEventListener('click', async () => {
+  clearNotice($('share-msg'));
+  const patientSel = $('share-patient');
+  const [recipientOrganization, recipientDisplay] = $('share-recipient').value.split('|');
+
+  const start = $('share-start').value;
+  const end = $('share-end').value;
+  if (!start || !end) {
+    notice($('share-msg'), 'Set both a start and an end for the sharing window.');
+    return;
+  }
+  // Echo both instants back: an inverted window is usually a mistyped day, and
+  // seeing the two dates side by side makes that obvious.
+  if (new Date(end) <= new Date(start)) {
+    notice($('share-msg'),
+      `The window ends before it starts — access would never open. ` +
+      `Starts ${fmtDateTime(new Date(start).getTime())}, ` +
+      `ends ${fmtDateTime(new Date(end).getTime())}.`);
+    return;
+  }
+
+  $('create-share').disabled = true;
+  try {
+    const res = await fetch('/demo/shares', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        patient: patientSel.value,
+        patientName: patientSel.selectedOptions[0]?.dataset.name,
+        recipientOrganization,
+        recipientDisplay,
+        // Send ISO so the server reads the same instant the picker showed.
+        start: new Date(start).toISOString(),
+        end: new Date(end).toISOString(),
+        hiddenItems: hiddenItems(),
+        shareScore: $('share-score').checked,
+        passcode: $('share-passcode').value.trim() || undefined,
+      }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Could not create the share');
+
+    $('share-link').textContent = data.shlink;
+    $('share-linkbox').classList.remove('hidden');
+    const hidden = hiddenItems();
+    notice($('share-msg'),
+      `Share created — open until ${fmtDateTime(data.endsAt * 1000)}` +
+      (hidden.length
+        ? `, ${hidden.length} question${hidden.length > 1 ? 's' : ''} withheld`
+        : ', nothing withheld') +
+      ($('share-score').checked ? '.' : ', score withheld.'), 'ok');
+  } catch (err) {
+    notice($('share-msg'), err.message);
+  } finally {
+    $('create-share').disabled = false;
+  }
+});
+
+$('copy-link').addEventListener('click', async () => {
+  await navigator.clipboard.writeText($('share-link').textContent);
+  $('copy-link').textContent = 'Copied';
+  setTimeout(() => { $('copy-link').textContent = 'Copy'; }, 1400);
+});
+
+$('open-link').addEventListener('click', () => {
+  openAsRecipient($('share-link').textContent, $('share-passcode').value.trim());
+});
+
+function openAsRecipient(shlink, passcode = '') {
+  $('shl-input').value = shlink;
+  $('recv-passcode').value = passcode;
+  showRole('receive');
+  resolveLink();
+}
+
+/* ---------------------- 3. manage ---------------------- */
+
+const STATE_LABEL = {
+  open: 'open',
+  ended: 'ended',
+  revoked: 'closed early',
+  'not-yet-started': 'not started',
+};
+
+async function loadShares() {
+  const res = await fetch('/demo/shares');
+  const list = await res.json();
+  if (!Array.isArray(list) || list.length === 0) {
+    $('shares-list').innerHTML = '<p class="empty">No shares granted yet.</p>';
+    return;
+  }
+
+  $('shares-list').innerHTML = list.map((s) => {
+    const badgeClass = s.state === 'open' ? 'open'
+      : s.state === 'not-yet-started' ? 'pending' : s.state;
+    const withheld = s.hiddenItems.length ? s.hiddenItems.join(', ') : 'nothing';
+
+    const last = s.accessLog[s.accessLog.length - 1];
+    const reads = last
+      ? `${s.accessLog.length} read${s.accessLog.length > 1 ? 's' : ''}, last ` +
+        `${fmtDateTime(last.atMs)} — ${last.responseCount} assessment` +
+        `${last.responseCount === 1 ? '' : 's'} visible then`
+      : 'not read yet';
+
+    const closable = s.state === 'open' || s.state === 'not-yet-started';
+
+    return `
+      <div class="share">
+        <div class="share-head">
+          <span class="share-title">${esc(s.label)}</span>
+          <span class="badge ${badgeClass}">${esc(STATE_LABEL[s.state] ?? s.state)}</span>
+        </div>
+        <div class="share-meta">
+          <span>Shared with <b>${esc(s.recipient)}</b></span>
+          <span>Window <b>${esc(fmtDateTime(s.startsAt * 1000))}</b> → <b>${esc(fmtDateTime(s.endsAt * 1000))}</b></span>
+          <span>Withheld: <b>${esc(withheld)}</b>${s.shareScore ? '' : ' · <b>score withheld</b>'}</span>
+          <span>${s.hasPasscode ? 'Passcode required · ' : ''}${esc(reads)}</span>
+        </div>
+        <div class="row">
+          <button class="ghost small" data-open="${esc(s.shlink)}" type="button">Open as recipient</button>
+          ${closable
+            ? `<button class="danger small" data-revoke="${esc(s.shareId)}" type="button">Close now</button>`
+            : ''}
+        </div>
+      </div>`;
+  }).join('');
+
+  for (const btn of $('shares-list').querySelectorAll('[data-revoke]')) {
+    btn.addEventListener('click', async () => {
+      btn.disabled = true;
+      await fetch(`/demo/shares/${btn.dataset.revoke}/revoke`, { method: 'POST' });
+      await loadShares();
+    });
+  }
+  for (const btn of $('shares-list').querySelectorAll('[data-open]')) {
+    btn.addEventListener('click', () => openAsRecipient(btn.dataset.open));
+  }
+}
+
+$('refresh-shares').addEventListener('click', loadShares);
+
+/* ---------------------- 4. receive (the real SHL receiver) ---------------------- */
+
+/* --- the "behind the scenes" step log --- */
+let stepCount = 0;
+function resetSteps() {
+  stepCount = 0;
+  $('steps').innerHTML = '';
+  $('bts-toggle').classList.remove('hidden');
+}
+function addStep(title, where) {
+  const idx = stepCount++;
+  const li = document.createElement('li');
+  li.className = 'step active';
+  li.id = `step-${idx}`;
+  li.innerHTML = `
+    <button class="step-head" type="button" aria-expanded="false">
+      <span class="step-dot"></span>
+      <span>${esc(title)}</span>
+      <span class="step-where ${where}">${where === 'browser' ? 'in your browser' : 'server'}</span>
+    </button>
+    <div class="step-body hidden"></div>`;
+  const head = li.querySelector('.step-head');
+  head.addEventListener('click', () => {
+    const body = li.querySelector('.step-body');
+    const collapsed = body.classList.toggle('hidden');
+    head.setAttribute('aria-expanded', String(!collapsed));
+  });
+  $('steps').appendChild(li);
+  return idx;
+}
+function finishStep(idx, detail, ok = true) {
+  const li = $(`step-${idx}`);
+  li.className = `step ${ok ? 'done' : 'fail'}`;
+  li.querySelector('.step-body').innerHTML = detail;
+}
+function truncate(s, n = 240) {
+  const str = String(s);
+  return str.length > n ? `${str.slice(0, n)}… (${str.length} chars total)` : str;
+}
+function detailBlock(pairs) {
+  return pairs.map(([lbl, val]) => `<span class="lbl">${esc(lbl)}</span>${esc(val)}`).join('');
+}
+
+/* --- shlink: decoding --- */
+function b64urlToBytes(s) {
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+  const bin = atob(padded);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+function decodeShlink(shlink) {
+  const marker = 'shlink:/';
+  const idx = shlink.indexOf(marker);
+  if (idx === -1) throw new Error('That is not a SMART Health Link — no "shlink:/" in it.');
+  const json = new TextDecoder().decode(b64urlToBytes(shlink.slice(idx + marker.length).trim()));
+  return JSON.parse(json);
+}
+
+/* --- JWE decryption, entirely in the browser --- */
+async function decryptJwe(jwe, keyB64url) {
+  const parts = jwe.split('.');
+  if (parts.length !== 5) throw new Error('Malformed JWE (expected five parts).');
+  const [protectedHeader, , iv, ciphertext, tag] = parts;
+  const key = await crypto.subtle.importKey(
+    'raw', b64urlToBytes(keyB64url), { name: 'AES-GCM' }, false, ['decrypt']);
+  // WebCrypto wants the auth tag appended to the ciphertext.
+  const ct = b64urlToBytes(ciphertext);
+  const tg = b64urlToBytes(tag);
+  const body = new Uint8Array(ct.length + tg.length);
+  body.set(ct);
+  body.set(tg, ct.length);
+  const plain = await crypto.subtle.decrypt(
+    {
+      name: 'AES-GCM',
+      iv: b64urlToBytes(iv),
+      // The protected header is the JWE's AAD, as its original base64url text.
+      additionalData: new TextEncoder().encode(protectedHeader),
+      tagLength: 128,
+    },
+    key, body);
+  return new TextDecoder().decode(plain);
+}
+
+async function resolveLink() {
+  clearNotice($('recv-msg'));
+  $('reveal').classList.add('hidden');
+  resetSteps();
+
+  const raw = $('shl-input').value.trim();
+  if (!raw) { notice($('recv-msg'), 'Paste a SMART Health Link first.'); return; }
+
+  $('resolve-link').disabled = true;
+  try {
+    // --- read the link (nothing leaves the browser yet) ---
+    let s = addStep('Read the link', 'browser');
+    const payload = decodeShlink(raw);
+    finishStep(s, detailBlock([
+      ['Manifest URL', payload.url],
+      ['Flags', `${payload.flag ?? '—'}${payload.flag?.includes('P') ? '  (passcode required)' : ''}`],
+      ['Label', payload.label ?? '—'],
+      ['Access ends', payload.exp ? new Date(payload.exp * 1000).toLocaleString() : 'not stated'],
+      ['Decryption key', `${truncate(payload.key, 10)} — stays in this browser`],
+    ]));
+
+    // The link states its own expiry, so a receiver can see a closed window
+    // without calling the server at all.
+    if (payload.exp && payload.exp * 1000 < Date.now()) {
+      s = addStep('Check the sharing window', 'browser');
+      finishStep(s, detailBlock([
+        ['Result', 'The window has ended — the link carries its own expiry.'],
+      ]), false);
+      showNoContent('closed', 'This share has ended. The sharing organization set it to ' +
+        `close on ${new Date(payload.exp * 1000).toLocaleString()}.`);
+      return;
+    }
+
+    // --- ask the manifest what's available ---
+    s = addStep('Ask the manifest what is available', 'server');
+    const body = { recipient: $('recv-recipient').value.trim() || 'Recipient organization' };
+    const passcode = $('recv-passcode').value.trim();
+    if (passcode) body.passcode = passcode;
+
+    const manifestRes = await fetch(payload.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const manifestText = await manifestRes.text();
+    let manifest = {};
+    try { manifest = JSON.parse(manifestText); } catch { /* leave as {} */ }
+
+    finishStep(s, detailBlock([
+      ['Request', `POST ${payload.url}\n${JSON.stringify(body, null, 2)}`],
+      ['Response', `${manifestRes.status} ${manifestRes.statusText}\n${truncate(manifestText, 420)}`],
+    ]), manifestRes.ok);
+
+    if (manifestRes.status === 401) {
+      notice($('recv-msg'), manifest.remainingAttempts !== undefined
+        ? `Wrong passcode. ${manifest.remainingAttempts} attempt` +
+          `${manifest.remainingAttempts === 1 ? '' : 's'} left before the link locks for good.`
+        : 'This link needs a passcode. The sharing organization sends it separately.');
+      return;
+    }
+    if (manifestRes.status === 429) {
+      notice($('recv-msg'), 'Too many requests for this link. Try again in ' +
+        `${manifestRes.headers.get('Retry-After') ?? 'a few'} seconds.`);
+      return;
+    }
+    if (!manifestRes.ok) {
+      notice($('recv-msg'),
+        manifest?.issue?.[0]?.details?.text ?? 'The manifest request failed.');
+      return;
+    }
+
+    if (manifest.status === 'no-longer-valid') {
+      showNoContent('closed', 'This share is closed — either the window ended, or the ' +
+        'sharing organization closed it early.');
+      return;
+    }
+    if (!manifest.files?.length) {
+      showNoContent('pending',
+        'The share exists, but there is nothing to read yet — its window has not opened.');
+      return;
+    }
+
+    // --- get the ciphertext, embedded or via a short-lived location URL ---
+    const file = manifest.files[0];
+    let jwe = file.embedded;
+    if (!jwe && file.location) {
+      s = addStep('Fetch the encrypted file', 'server');
+      const fileRes = await fetch(file.location);
+      const fileText = await fileRes.text();
+      finishStep(s, detailBlock([
+        ['Request', `GET ${file.location}`],
+        ['Response', `${fileRes.status} ${fileRes.statusText}\n${truncate(fileText)}`],
+      ]), fileRes.ok);
+      if (!fileRes.ok) {
+        notice($('recv-msg'), 'That file link has expired. Open the share again for a fresh one.');
+        return;
+      }
+      jwe = fileText;
+    } else {
+      s = addStep('Take the encrypted file from the manifest', 'server');
+      finishStep(s, detailBlock([
+        ['Ciphertext (JWE)', truncate(jwe)],
+        ['Note', 'The server only ever handed over ciphertext — it cannot read this.'],
+      ]));
+    }
+
+    // --- decrypt locally ---
+    s = addStep('Decrypt it here, in your browser', 'browser');
+    let bundle;
+    try {
+      bundle = JSON.parse(await decryptJwe(jwe, payload.key));
+      finishStep(s, detailBlock([
+        ['Method', 'AES-256-GCM via WebCrypto, using the key carried in the link'],
+        ['Result', `A FHIR ${bundle.resourceType} holding ${bundle.total ?? 0} assessment(s)`],
+      ]));
+    } catch (err) {
+      finishStep(s, detailBlock([['Error', err.message]]), false);
+      notice($('recv-msg'), 'Could not decrypt the contents — the key in this link does not match.');
+      return;
+    }
+
+    renderBundle(bundle, manifest.status);
+  } catch (err) {
+    notice($('recv-msg'), err.message);
+  } finally {
+    $('resolve-link').disabled = false;
+  }
+}
+
+/** Render the no-content states: a closed window, or one that hasn't opened yet. */
+function showNoContent(kind, text) {
+  const closed = kind === 'closed';
+  $('reveal').classList.remove('hidden');
+  $('window-note').className = closed ? 'window-note closed' : 'window-note';
+  $('window-note').textContent = text;
+  $('reveal-badge').className = `badge ${closed ? 'revoked' : 'pending'}`;
+  $('reveal-badge').textContent = closed ? 'closed' : 'not started';
+  $('responses').innerHTML = `<p class="empty">${
+    closed ? 'Nothing is available through this link.' : 'Nothing to read yet.'}</p>`;
+}
+
+function renderBundle(bundle, manifestStatus) {
+  $('reveal').classList.remove('hidden');
+  $('reveal-badge').className = 'badge open';
+  $('reveal-badge').textContent = manifestStatus === 'can-change' ? 'open' : manifestStatus;
+
+  // The bundle states the terms it was produced under, so the receiver reads the
+  // window and the redaction from the data itself rather than from this page.
+  const win = bundle.extension?.find((e) => e.url === WINDOW_EXT);
+  const sub = (url) => win?.extension?.find((e) => e.url === url);
+  const start = sub('start')?.valueInstant;
+  const end = sub('end')?.valueInstant;
+  const by = sub('sharedBy')?.valueString;
+
+  $('window-note').className = 'window-note';
+  $('window-note').innerHTML =
+    `Shared by <b>${esc(by ?? 'the sending organization')}</b> until ` +
+    `<b>${esc(end ? new Date(end).toLocaleString() : 'an unstated date')}</b>. ` +
+    `Assessments they complete before then will appear here next time you open the link. ` +
+    `Access opened ${esc(start ? new Date(start).toLocaleString() : 'earlier')}.`;
+
+  const entries = bundle.entry ?? [];
+  if (entries.length === 0) {
+    $('responses').innerHTML =
+      '<p class="empty">No assessments have been completed for this patient yet.</p>';
+    return;
+  }
+
+  $('responses').innerHTML = entries.slice().reverse()
+    .map(({ resource }) => renderResponse(resource)).join('');
+}
+
+function renderResponse(qr) {
+  const total = qr.extension?.find((e) => e.url === SCORE_EXT)?.valueDecimal;
+
+  const items = (qr.item ?? []).map((item) => {
+    const masked = item.extension?.some((e) => e.url === MASKED_EXT);
+    if (masked) {
+      return `
+        <div class="ans masked">
+          <span class="ans-q">${esc(item.text ?? item.linkId)}</span>
+          <span class="ans-v">withheld</span>
+        </div>`;
+    }
+    // The sender always writes `display` alongside the code (see
+    // assessment-service.buildItems), so the code itself is the only fallback
+    // needed — and showing the raw code beats showing nothing.
+    const coding = item.answer?.[0]?.valueCoding;
+    const display = coding?.display ?? coding?.code ?? '—';
+    return `
+      <div class="ans">
+        <span class="ans-q">${esc(item.text ?? item.linkId)}</span>
+        <span class="ans-v">${esc(display)}</span>
+      </div>`;
+  }).join('');
+
+  const scoreBlock = total === undefined
+    ? `<span class="resp-score withheld">
+         <span class="n">score withheld</span>
+         <span class="b">not shared</span>
+       </span>`
+    : `<span class="resp-score">
+         <span class="n">${esc(total)}</span><span class="score-max">/21</span>
+         <span class="b">${esc(severity(total))}</span>
+       </span>`;
+
+  return `
+    <div class="resp">
+      <div class="resp-head">
+        <span class="resp-date">${esc(fmtDate(qr.authored))}</span>
+        ${scoreBlock}
+      </div>
+      <div class="answers">${items}</div>
+    </div>`;
+}
+
+$('resolve-link').addEventListener('click', resolveLink);
+$('clear-link').addEventListener('click', () => {
+  $('shl-input').value = '';
+  $('recv-passcode').value = '';
+  clearNotice($('recv-msg'));
+  $('reveal').classList.add('hidden');
+  $('bts').classList.add('hidden');
+  $('bts-toggle').classList.add('hidden');
+  $('bts-toggle').setAttribute('aria-expanded', 'false');
+  history.replaceState(null, '', location.pathname);
+});
+
+$('bts-toggle').addEventListener('click', () => {
+  const open = $('bts-toggle').getAttribute('aria-expanded') === 'true';
+  $('bts-toggle').setAttribute('aria-expanded', String(!open));
+  $('bts').classList.toggle('hidden', open);
+});
+
+/* ---------------------- bootstrap ---------------------- */
+
+async function loadPatients() {
+  const res = await fetch('/demo/patients');
+  const list = await res.json();
+  $('share-patient').innerHTML = list.map((p) =>
+    `<option value="${esc(p.reference)}" data-name="${esc(p.name)}">${esc(p.name)}${
+      p.birthDate ? ` · b. ${esc(p.birthDate)}` : ''}</option>`).join('');
+}
+
+// Keep the "assessments on file" list in step with the share tab's patient.
+$('share-patient').addEventListener('change', loadHistory);
+
+async function init() {
+  // Independent endpoints — fetch them together. The others need the contract
+  // (scored linkIds) and the patient select populated first, so they wait.
+  await Promise.all([loadFormContract(), loadPatients()]);
+  await Promise.all([renderHideItems(), loadHistory()]);
+
+  // A minted link opens this page with the shlink: in the fragment — jump
+  // straight to the recipient view and resolve it, as a real receiver would.
+  const frag = decodeURIComponent(location.hash.slice(1));
+  if (frag.includes('shlink:/')) {
+    showRole('receive');
+    openAsRecipient(frag);
+  }
+}
+
+init();
+</script>
+
+<!--
+  The React intake island. Loaded after the page script so #gad7-root exists,
+  and deferred so it never blocks the rest of the UI.
+-->
+<script type="module" src="/assets/intake.js"></script>
+</body>
+</html>

--- a/aidbox-integrations/shared-assessment-link/src/forms/intake.tsx
+++ b/aidbox-integrations/shared-assessment-link/src/forms/intake.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import Renderer from '@formbox/renderer';
+import { theme } from '@formbox/hs-theme';
+import '@formbox/hs-theme/style.css';
+
+/**
+ * The GAD-7 intake form, rendered by @formbox/renderer — the same FHIR
+ * Questionnaire renderer HealthSamurai/phr uses.
+ *
+ * This is a React "island": the surrounding page (share builder, dashboard,
+ * recipient viewer) stays plain no-build HTML, and only this form is bundled.
+ * `Bun.build()` in server.ts compiles it, so there is still no separate build
+ * step to run — the server does it on boot.
+ *
+ * Why a real renderer rather than the hand-rolled radio buttons it replaces:
+ * the form is now driven by the `Questionnaire/gad7` resource in Aidbox, so the
+ * instrument is defined once, in FHIR, instead of duplicated in TypeScript. The
+ * renderer also gives us enableWhen, validation, and `answerValueSet` expansion
+ * against Aidbox's terminology server for free.
+ */
+
+/** Shape of the payload served by GET /demo/intake-form. */
+interface IntakeConfig {
+  /**
+   * The FHIR Questionnaire to render. Its items carry inline `answerOption`, so
+   * the renderer needs no terminology server and the browser needs no Aidbox
+   * credentials to resolve the answer choices.
+   */
+  questionnaire: Record<string, unknown>;
+  /** Patients the sharing organization can record against. */
+  patients: Array<{ reference: string; name: string; birthDate?: string }>;
+}
+
+type Submitted = { total: number };
+
+function IntakeForm(): React.JSX.Element {
+  const [config, setConfig] = useState<IntakeConfig | null>(null);
+  const [patient, setPatient] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState<Submitted | null>(null);
+  const [busy, setBusy] = useState(false);
+  // Remounts the renderer after a save so the next assessment starts blank.
+  const [formKey, setFormKey] = useState(0);
+
+  useEffect(() => {
+    fetch('/demo/intake-form')
+      .then((r) => r.json() as Promise<IntakeConfig>)
+      .then((c) => {
+        setConfig(c);
+        setPatient(c.patients[0]?.reference ?? '');
+      })
+      .catch(() => setError('Could not load the questionnaire.'));
+  }, []);
+
+  /**
+   * The renderer hands back a complete FHIR QuestionnaireResponse once its own
+   * validation passes. We post it as-is; the server stamps the authoring
+   * organization and computes the score, so neither is client-controlled.
+   */
+  async function handleSubmit(response: unknown): Promise<void> {
+    setError(null);
+    setSaved(null);
+    setBusy(true);
+    try {
+      const res = await fetch('/demo/assessments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ patient, questionnaireResponse: response }),
+      });
+      const data = (await res.json()) as { total?: number; error?: string };
+      if (!res.ok) throw new Error(data.error || 'Could not save the assessment');
+      setSaved({ total: data.total ?? 0 });
+      setFormKey((k) => k + 1);
+      // Let the surrounding page refresh its "assessments on file" list.
+      window.dispatchEvent(new CustomEvent('assessment-saved'));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not save the assessment');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (error && !config) return <p className="empty">{error}</p>;
+  if (!config) return <p className="empty">Loading the questionnaire…</p>;
+
+  return (
+    <>
+      <div className="field">
+        <label className="fld" htmlFor="formbox-patient">
+          Patient
+        </label>
+        <select
+          id="formbox-patient"
+          value={patient}
+          onChange={(e) => setPatient(e.target.value)}
+        >
+          {config.patients.map((p) => (
+            <option key={p.reference} value={p.reference}>
+              {p.name}
+              {p.birthDate ? ` · b. ${p.birthDate}` : ''}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="formbox-wrap" aria-busy={busy}>
+        <Renderer
+          key={formKey}
+          fhirVersion="r4"
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          questionnaire={config.questionnaire as any}
+          theme={theme}
+          onSubmit={handleSubmit}
+        />
+      </div>
+
+      {saved && (
+        <div className="ok-note">
+          Saved — total {saved.total}/21. Any open share for this patient now includes it.
+        </div>
+      )}
+      {error && <div className="err">{error}</div>}
+    </>
+  );
+}
+
+const mount = document.getElementById('gad7-root');
+if (mount) createRoot(mount).render(<IntakeForm />);

--- a/aidbox-integrations/shared-assessment-link/src/handlers/share.ts
+++ b/aidbox-integrations/shared-assessment-link/src/handlers/share.ts
@@ -1,0 +1,226 @@
+import type { AidboxOperationRequest, ManifestRequestBody } from '../types/operation.ts';
+import type { ShareService } from '../services/share-service.ts';
+import type { Config } from '../types/config.ts';
+import { GAD7_QUESTIONNAIRE_URL } from '../types/gad7.ts';
+
+/** JSON Response helper. */
+function json(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+function operationOutcome(
+  severity: string,
+  code: string,
+  text: string,
+  status: number
+): Response {
+  return json(
+    { resourceType: 'OperationOutcome', issue: [{ severity, code, details: { text } }] },
+    status
+  );
+}
+
+/**
+ * Handles the Aidbox App operations behind the assessment-sharing flow.
+ * Each method maps one `operation.id` configured in the init bundle.
+ */
+export class ShareHandler {
+  constructor(
+    private readonly shares: ShareService,
+    private readonly config: Config
+  ) {}
+
+  /**
+   * operation `share-create`: Provider A grants Provider B time-bounded access.
+   * Authenticated — only the sharing organization may create a grant.
+   */
+  async handleCreate(op: AidboxOperationRequest): Promise<Response> {
+    const params = extractParameters(op.request.resource);
+
+    const patient = params.patient;
+    const recipientOrganization = params.recipientOrganization;
+    if (!patient || !recipientOrganization) {
+      return operationOutcome(
+        'error',
+        'invalid',
+        'patient and recipientOrganization parameters are required',
+        400
+      );
+    }
+
+    const startsAt = parseEpoch(params.start) ?? Math.floor(Date.now() / 1000);
+    const endsAt = parseEpoch(params.end);
+    if (endsAt === undefined) {
+      return operationOutcome(
+        'error',
+        'invalid',
+        'end parameter is required (ISO date/dateTime or epoch seconds)',
+        400
+      );
+    }
+    // createShare owns the window invariant; its message surfaces via the catch.
+    try {
+      const result = await this.shares.createShare({
+        label: params.label ?? `GAD-7 assessments (${patient})`,
+        sourceOrganization: params.sourceOrganization ?? this.config.share.sourceOrganization,
+        recipientOrganization,
+        recipientDisplay: params.recipientDisplay,
+        patient,
+        questionnaire: params.questionnaire ?? GAD7_QUESTIONNAIRE_URL,
+        startsAt,
+        endsAt,
+        // Comma-separated linkIds, e.g. "gad7-q4,gad7-q8".
+        hiddenItems: splitList(params.hiddenItems),
+        shareScore: params.shareScore !== 'false',
+        passcode: params.passcode,
+      });
+
+      return json({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'shareId', valueString: result.shareId },
+          { name: 'shlink', valueString: result.shlink },
+          { name: 'manifestUrl', valueString: result.payload.url },
+          { name: 'expiresAt', valueString: new Date(endsAt * 1000).toISOString() },
+        ],
+      });
+    } catch (err) {
+      return operationOutcome(
+        'error',
+        'invalid',
+        err instanceof Error ? err.message : 'Could not create the share',
+        400
+      );
+    }
+  }
+
+  /** operation `share-revoke`: Provider A closes a share before its end date. */
+  async handleRevoke(op: AidboxOperationRequest): Promise<Response> {
+    const shareId = op.request['route-params'].shareId;
+    if (!shareId) {
+      return operationOutcome('error', 'invalid', 'Missing shareId', 400);
+    }
+
+    const share = await this.shares.revokeShare(shareId);
+    if (!share) {
+      return operationOutcome('error', 'not-found', 'Unknown share', 404);
+    }
+
+    return json({
+      resourceType: 'Parameters',
+      parameter: [
+        { name: 'shareId', valueString: share.id! },
+        { name: 'status', valueString: share.status },
+        {
+          name: 'revokedAt',
+          valueString: new Date((share.revokedAt ?? 0) * 1000).toISOString(),
+        },
+      ],
+    });
+  }
+
+  /** operation `share-manifest`: the SHL receiver (Provider B) POSTs the manifest URL. */
+  async handleManifest(op: AidboxOperationRequest): Promise<Response> {
+    const shareId = op.request['route-params'].shareId;
+    if (!shareId) {
+      return operationOutcome('error', 'invalid', 'Missing shareId', 400);
+    }
+
+    const body = (op.request.resource ?? {}) as ManifestRequestBody;
+    if (!body.recipient) {
+      return operationOutcome('error', 'invalid', 'recipient is required', 400);
+    }
+
+    const result = await this.shares.getManifest(shareId, {
+      embeddedLengthMax: body.embeddedLengthMax,
+      passcode: body.passcode,
+      recipient: body.recipient,
+    });
+
+    switch (result.kind) {
+      case 'ok':
+        return json(result.manifest);
+      case 'not-found':
+        return operationOutcome('error', 'not-found', 'Unknown SMART Health Link', 404);
+      case 'passcode-required':
+        // Spec: a passcode is required to resolve this link.
+        return json({ message: 'Passcode required' }, 401);
+      case 'passcode-invalid':
+        // Spec: reject and report remaining lifetime attempts.
+        return json({ remainingAttempts: result.remainingAttempts }, 401);
+      case 'rate-limited':
+        return json({ message: 'Too many requests' }, 429, {
+          'Retry-After': String(result.retryAfterSeconds),
+        });
+    }
+  }
+
+  /** operation `share-file`: the receiver GETs a short-lived file location. */
+  async handleFile(op: AidboxOperationRequest): Promise<Response> {
+    const token = op.request['route-params'].fileId;
+    if (!token) {
+      return operationOutcome('error', 'invalid', 'Missing file token', 400);
+    }
+
+    const result = await this.shares.getFile(token);
+    switch (result.kind) {
+      case 'ok':
+        // Per spec, file locations return the JWE with content-type application/jose.
+        return new Response(result.jwe, {
+          status: 200,
+          headers: { 'Content-Type': 'application/jose' },
+        });
+      case 'gone':
+        // The location URL expired, or the share window closed under it.
+        return operationOutcome('error', 'expired', 'This share link is no longer available', 410);
+      case 'not-found':
+        return operationOutcome('error', 'not-found', 'File not available', 404);
+    }
+  }
+}
+
+/** Pull simple string params out of a FHIR Parameters resource. */
+function extractParameters(resource: unknown): Record<string, string | undefined> {
+  const out: Record<string, string | undefined> = {};
+  const params = (
+    resource as {
+      parameter?: Array<{
+        name: string;
+        valueString?: string;
+        valueBoolean?: boolean;
+        valueDateTime?: string;
+        valueDate?: string;
+        valueInteger?: number;
+      }>;
+    }
+  )?.parameter;
+  if (Array.isArray(params)) {
+    for (const p of params) {
+      if (p.valueString !== undefined) out[p.name] = p.valueString;
+      else if (p.valueDateTime !== undefined) out[p.name] = p.valueDateTime;
+      else if (p.valueDate !== undefined) out[p.name] = p.valueDate;
+      else if (p.valueBoolean !== undefined) out[p.name] = String(p.valueBoolean);
+      else if (p.valueInteger !== undefined) out[p.name] = String(p.valueInteger);
+    }
+  }
+  return out;
+}
+
+/** Accept either an ISO date/dateTime or raw epoch seconds for the window bounds. */
+export function parseEpoch(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  if (/^\d+$/.test(value)) return parseInt(value, 10);
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? undefined : Math.floor(ms / 1000);
+}
+
+function splitList(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}

--- a/aidbox-integrations/shared-assessment-link/src/server.ts
+++ b/aidbox-integrations/shared-assessment-link/src/server.ts
@@ -1,0 +1,397 @@
+import { loadConfig } from './types/config.ts';
+import type { AidboxOperationRequest } from './types/operation.ts';
+import { FhirClient } from './services/fhir-client.ts';
+import { ShareStore } from './services/share-store.ts';
+import {
+  AssessmentService,
+  gad7TotalOf,
+  GAD7_SCORE_EXTENSION,
+} from './services/assessment-service.ts';
+import type { Gad7Answer } from './services/assessment-service.ts';
+import { ShareContentProvider, SHARE_WINDOW_EXTENSION } from './services/share-content.ts';
+import { REDACTED_EXTENSION } from './services/redaction.ts';
+import { ShareService } from './services/share-service.ts';
+import { ShareHandler, parseEpoch } from './handlers/share.ts';
+import {
+  GAD7_QUESTIONNAIRE_URL,
+  GAD7_QUESTIONNAIRE_ID,
+  GAD7_SCORED_LINK_IDS,
+} from './types/gad7.ts';
+import type { QuestionnaireResponseItem } from './types/fhir.ts';
+
+const config = loadConfig();
+
+/** The sharing organization this app acts as (Provider A). Seeded by the init bundle. */
+const PROVIDER_A = config.share.sourceOrganization;
+
+// Wire up dependencies.
+//
+// ShareService is the SHL protocol engine: it owns the link, the window and the
+// security plumbing, and asks a ContentProvider for bytes on every poll.
+// ShareContentProvider is the use-case layer: it queries live assessments and
+// applies Provider A's field-level policy. The engine never sees an assessment.
+const fhir = new FhirClient(config);
+const assessments = new AssessmentService(fhir);
+const store = new ShareStore(fhir);
+const shares = new ShareService(config, {
+  store,
+  content: new ShareContentProvider(assessments),
+});
+const handler = new ShareHandler(shares, config);
+
+// The browser UI: intake form, share builder, and the recipient's viewer.
+const appHtml = await Bun.file(new URL('./app.html', import.meta.url)).text();
+
+/**
+ * Bundle the React intake form at boot.
+ *
+ * The GAD-7 form is rendered by @formbox/renderer, which needs a bundler (its
+ * dist imports bare specifiers). Building here keeps the project's "no build
+ * step to run" property: `bun src/server.ts` still starts everything. The rest
+ * of the UI stays plain no-build HTML — only this island is compiled.
+ */
+async function buildIntakeBundle(): Promise<{ js: string; css: string }> {
+  const result = await Bun.build({
+    entrypoints: [new URL('./forms/intake.tsx', import.meta.url).pathname],
+    target: 'browser',
+    minify: true,
+    define: { 'process.env.NODE_ENV': '"production"' },
+  });
+
+  if (!result.success) {
+    throw new AggregateError(result.logs, 'Failed to bundle the intake form');
+  }
+
+  let js = '';
+  let css = '';
+  for (const output of result.outputs) {
+    if (output.kind === 'entry-point' || output.path.endsWith('.js')) js += await output.text();
+    else if (output.path.endsWith('.css')) css += await output.text();
+  }
+  return { js, css };
+}
+
+const intakeBundle = await buildIntakeBundle();
+
+/**
+ * Aidbox routes every configured App operation to this single endpoint and
+ * dispatches by `operation.id`. We mirror that pattern here.
+ */
+async function dispatch(op: AidboxOperationRequest): Promise<Response> {
+  switch (op.operation.id) {
+    case 'share-create':
+      return handler.handleCreate(op);
+    case 'share-revoke':
+      return handler.handleRevoke(op);
+    case 'share-manifest':
+      return handler.handleManifest(op);
+    case 'share-file':
+      return handler.handleFile(op);
+    default:
+      return new Response(
+        JSON.stringify({ error: `Unsupported operation: ${op.operation.id}` }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+  }
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const server = Bun.serve({
+  port: config.server.port,
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    if (req.method === 'GET' && url.pathname === '/health') {
+      return json({
+        status: 'healthy',
+        service: 'aidbox-shared-assessment-link',
+        timestamp: new Date().toISOString(),
+      });
+    }
+
+    // The demo UI (intake + share builder + recipient viewer).
+    if (req.method === 'GET' && (url.pathname === '/' || url.pathname === '/app')) {
+      return new Response(appHtml, {
+        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+      });
+    }
+
+    // The bundled React intake form and the theme's stylesheet.
+    if (req.method === 'GET' && url.pathname === '/assets/intake.js') {
+      return new Response(intakeBundle.js, {
+        headers: { 'Content-Type': 'text/javascript; charset=utf-8' },
+      });
+    }
+    if (req.method === 'GET' && url.pathname === '/assets/intake.css') {
+      return new Response(intakeBundle.css, {
+        headers: { 'Content-Type': 'text/css; charset=utf-8' },
+      });
+    }
+
+    // ---------------------------------------------------------------------
+    // Demo-only routes.
+    //
+    // In production these are authenticated back-office actions inside Provider
+    // A's system (the `share-create` / `share-revoke` Aidbox operations). Here
+    // the app exposes unauthenticated convenience routes so the demo page can
+    // drive the flow without putting Aidbox credentials in the browser.
+    // ---------------------------------------------------------------------
+
+    /**
+     * Everything the React intake island needs: the Questionnaire *as stored in
+     * Aidbox* (so the instrument is defined once, in FHIR), the terminology base
+     * the renderer expands `answerValueSet`s against, and the patient list.
+     */
+    if (req.method === 'GET' && url.pathname === '/demo/intake-form') {
+      const questionnaire = await fhir.read<Record<string, unknown>>(
+        'Questionnaire',
+        GAD7_QUESTIONNAIRE_ID
+      );
+      if (!questionnaire) {
+        return json({ error: `Questionnaire/${GAD7_QUESTIONNAIRE_ID} not found in Aidbox` }, 404);
+      }
+      // No terminologyServerUrl: the GAD-7's items carry inline `answerOption`,
+      // so the renderer needs no $expand round trip — which also means the
+      // browser never needs credentials for Aidbox's terminology endpoints.
+      return json({ questionnaire, patients: await listPatients() });
+    }
+
+    /**
+     * The extension URLs the recipient viewer reads, so the wire contract is
+     * defined once on the server rather than re-declared in the page.
+     */
+    if (req.method === 'GET' && url.pathname === '/demo/extensions') {
+      return json({
+        score: GAD7_SCORE_EXTENSION,
+        masked: REDACTED_EXTENSION,
+        window: SHARE_WINDOW_EXTENSION,
+        // Which items feed the total — the share builder flags the rest, since
+        // hiding an unscored item cannot move the score.
+        scoredLinkIds: GAD7_SCORED_LINK_IDS,
+      });
+    }
+
+    /** Provider A's patients. */
+    if (req.method === 'GET' && url.pathname === '/demo/patients') {
+      return json(await listPatients());
+    }
+
+    /** Submit a completed GAD-7 (Provider A captures an assessment). */
+    if (req.method === 'POST' && url.pathname === '/demo/assessments') {
+      let body: {
+        patient?: string;
+        /** Coded answers (API / seed path). */
+        answers?: Gad7Answer[];
+        /** A renderer-produced QuestionnaireResponse (the form path). */
+        questionnaireResponse?: { item?: QuestionnaireResponseItem[] };
+        authored?: string;
+      };
+      try {
+        body = (await req.json()) as typeof body;
+      } catch {
+        return json({ error: 'Invalid JSON body' }, 400);
+      }
+      const items = body.questionnaireResponse?.item;
+      if (!body.patient || (!items?.length && !body.answers?.length)) {
+        return json(
+          { error: 'patient plus either questionnaireResponse.item or answers is required' },
+          400
+        );
+      }
+      try {
+        const created = await assessments.submitGad7({
+          patient: body.patient,
+          sourceOrganization: PROVIDER_A,
+          ...(items?.length ? { items } : { answers: body.answers }),
+          authored: body.authored,
+        });
+        return json({
+          id: created.id,
+          authored: created.authored,
+          total: gad7TotalOf(created),
+        });
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('Assessment submit error:', err);
+        // Surface the underlying reason: a FHIR validation rejection is a bug in
+        // the resource we built, and "something went wrong" hides it.
+        return json(
+          { error: err instanceof Error ? err.message : 'Could not save the assessment' },
+          500
+        );
+      }
+    }
+
+    /** Provider A's assessments for one patient (the sharing side's own view). */
+    if (req.method === 'GET' && url.pathname === '/demo/assessments') {
+      const patient = url.searchParams.get('patient');
+      if (!patient) return json({ error: 'patient query parameter is required' }, 400);
+      const responses = await assessments.listGad7({
+        patient,
+        sourceOrganization: PROVIDER_A,
+      });
+      return json(
+        responses.map((r) => ({ id: r.id, authored: r.authored, total: gad7TotalOf(r) }))
+      );
+    }
+
+    /** Create a share and mint the shlink: (Provider A grants access). */
+    if (req.method === 'POST' && url.pathname === '/demo/shares') {
+      let body: {
+        patient?: string;
+        patientName?: string;
+        recipientOrganization?: string;
+        recipientDisplay?: string;
+        start?: string;
+        end?: string;
+        hiddenItems?: string[];
+        shareScore?: boolean;
+        passcode?: string;
+      };
+      try {
+        body = (await req.json()) as typeof body;
+      } catch {
+        return json({ error: 'Invalid JSON body' }, 400);
+      }
+      if (!body.patient || !body.recipientOrganization) {
+        return json({ error: 'patient and recipientOrganization are required' }, 400);
+      }
+
+      const startsAt = parseEpoch(body.start) ?? Math.floor(Date.now() / 1000);
+      const endsAt =
+        parseEpoch(body.end) ?? startsAt + config.share.defaultWindowDays * 86400;
+
+      // createShare owns the window invariant; its message surfaces via the catch.
+      try {
+        const result = await shares.createShare({
+          label: `GAD-7 assessments for ${body.patientName ?? body.patient}`,
+          sourceOrganization: PROVIDER_A,
+          recipientOrganization: body.recipientOrganization,
+          recipientDisplay: body.recipientDisplay,
+          patient: body.patient,
+          questionnaire: GAD7_QUESTIONNAIRE_URL,
+          startsAt,
+          endsAt,
+          hiddenItems: body.hiddenItems ?? [],
+          shareScore: body.shareScore !== false,
+          passcode: body.passcode,
+        });
+        return json({
+          shareId: result.shareId,
+          shlink: result.shlink,
+          manifestUrl: result.payload.url,
+          startsAt,
+          endsAt,
+        });
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('Share create error:', err);
+        return json(
+          { error: err instanceof Error ? err.message : 'Could not create the share' },
+          400
+        );
+      }
+    }
+
+    /** Provider A's dashboard: every share, its window, and who has read it. */
+    if (req.method === 'GET' && url.pathname === '/demo/shares') {
+      const all = await store.list();
+      return json(
+        all.map((s) => ({
+          shareId: s.id,
+          label: s.label,
+          patient: s.patient,
+          recipient: s.recipientDisplay ?? s.recipientOrganization,
+          startsAt: s.startsAt,
+          endsAt: s.endsAt,
+          hiddenItems: s.hiddenItems ?? [],
+          shareScore: s.shareScore !== false,
+          hasPasscode: Boolean(s.passcode),
+          status: s.status,
+          revokedAt: s.revokedAt,
+          state: shares.windowState(s),
+          shlink: shares.buildShlinkUri(s),
+          accessLog: s.accessLog ?? [],
+        }))
+      );
+    }
+
+    /** Revoke a share early (Provider A closes it before the end date). */
+    const revokeMatch = url.pathname.match(/^\/demo\/shares\/([^/]+)\/revoke$/);
+    if (req.method === 'POST' && revokeMatch) {
+      const share = await shares.revokeShare(revokeMatch[1]!);
+      if (!share) return json({ error: 'Unknown share' }, 404);
+      return json({ shareId: share.id, status: share.status, revokedAt: share.revokedAt });
+    }
+
+    // All Aidbox App operations arrive as POST to /share-app with the operation envelope.
+    if (req.method === 'POST' && url.pathname === '/share-app') {
+      let op: AidboxOperationRequest;
+      try {
+        op = (await req.json()) as AidboxOperationRequest;
+      } catch {
+        return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      try {
+        return await dispatch(op);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('Operation error:', err);
+        return new Response(
+          JSON.stringify({
+            resourceType: 'OperationOutcome',
+            issue: [
+              { severity: 'error', code: 'exception', details: { text: 'Internal error' } },
+            ],
+          }),
+          { status: 500, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+    }
+
+    return new Response(
+      JSON.stringify({
+        resourceType: 'OperationOutcome',
+        issue: [{ severity: 'error', code: 'not-found', details: { text: 'Not found' } }],
+      }),
+      { status: 404, headers: { 'Content-Type': 'application/json' } }
+    );
+  },
+});
+
+/** The patients this organization can record assessments against. */
+async function listPatients(): Promise<
+  Array<{ reference: string; name: string; birthDate?: string }>
+> {
+  const patients = await fhir.search<{
+    id?: string;
+    name?: Array<{ given?: string[]; family?: string }>;
+    birthDate?: string;
+  }>('Patient', [['_count', '20']]);
+  return patients.map((p) => ({
+    reference: `Patient/${p.id}`,
+    name: formatName(p.name),
+    birthDate: p.birthDate,
+  }));
+}
+
+function formatName(
+  name: Array<{ given?: string[]; family?: string }> | undefined
+): string {
+  const n = name?.[0];
+  if (!n) return 'Unknown patient';
+  return [n.given?.join(' '), n.family].filter(Boolean).join(' ') || 'Unknown patient';
+}
+
+// eslint-disable-next-line no-console
+console.log(`Shared assessment link service listening on port ${server.port}`);

--- a/aidbox-integrations/shared-assessment-link/src/services/assessment-service.ts
+++ b/aidbox-integrations/shared-assessment-link/src/services/assessment-service.ts
@@ -1,0 +1,185 @@
+import type { FhirClient } from './fhir-client.ts';
+import type { QuestionnaireResponse, QuestionnaireResponseItem } from '../types/fhir.ts';
+import {
+  GAD7_ANSWER_SYSTEM,
+  GAD7_CHOICES,
+  GAD7_DIFFICULTY_CHOICES,
+  GAD7_ITEMS,
+  GAD7_QUESTIONNAIRE_URL,
+  GAD7_SCORED_LINK_IDS,
+} from '../types/gad7.ts';
+
+/** URL of the extension carrying the computed GAD-7 total on a response. */
+export const GAD7_SCORE_EXTENSION = 'http://example.org/fhir/StructureDefinition/gad7-total-score';
+
+/**
+ * Most assessments one share will carry.
+ *
+ * A single page — the query does not follow `Bundle.link[next]`, so this is a
+ * hard ceiling, not a page size. At GAD-7's usual cadence it is a couple of
+ * years of history for one patient; a share that needs more should page.
+ */
+export const MAX_SHARED_RESPONSES = 100;
+
+/** One answered GAD-7 item as submitted by the intake form. */
+export interface Gad7Answer {
+  linkId: string;
+  /** The answer's code on its scale (e.g. `several-days`, or `very-difficult` for Q8). */
+  code: string;
+}
+
+/**
+ * Captures GAD-7 assessments as FHIR QuestionnaireResponses and reads them back.
+ *
+ * Provider Organization A's side of the use case: a patient fills in the
+ * questionnaire, the answers are stored as a `completed` QuestionnaireResponse
+ * stamped with A as the `source` organization, and the total score is carried in
+ * an extension so a recipient doesn't have to recompute it (and so A can choose
+ * to withhold it).
+ */
+export class AssessmentService {
+  constructor(private readonly fhir: FhirClient) {}
+
+  /**
+   * Persist one completed GAD-7 for a patient, attributed to the source organization.
+   *
+   * Accepts answers either as the renderer's `QuestionnaireResponse.item[]` (the
+   * form path) or as a list of `{ linkId, code }` pairs (the API/seed path).
+   * Either way this method — not the caller — sets `author`, `status` and the
+   * computed score, so a browser cannot claim an assessment belongs to another
+   * organization or assert its own total.
+   */
+  async submitGad7(input: {
+    patient: string;
+    sourceOrganization: string;
+    /** Coded answers, e.g. from the API or a seed script. */
+    answers?: Gad7Answer[];
+    /** Items straight off a renderer-produced QuestionnaireResponse. */
+    items?: QuestionnaireResponseItem[];
+    /** Authoring time; defaults to now. Lets the demo seed a history of past assessments. */
+    authored?: string;
+  }): Promise<QuestionnaireResponse> {
+    // Normalize the renderer's items to the same shape the coded path produces,
+    // so exactly one representation reaches Aidbox and the scorer.
+    const item = input.items ? normalizeItems(input.items) : buildItems(input.answers ?? []);
+    if (item.length === 0) {
+      throw new Error('A GAD-7 submission must contain at least one answered item');
+    }
+    const total = computeGad7Total(item);
+
+    const resource: QuestionnaireResponse = {
+      resourceType: 'QuestionnaireResponse',
+      questionnaire: GAD7_QUESTIONNAIRE_URL,
+      status: 'completed',
+      subject: { reference: input.patient },
+      authored: input.authored ?? new Date().toISOString(),
+      // `author` is how a share scopes to "assessments Provider A recorded".
+      author: { reference: input.sourceOrganization },
+      item,
+      extension: [{ url: GAD7_SCORE_EXTENSION, valueDecimal: total }],
+    };
+
+    return this.fhir.create<QuestionnaireResponse>('QuestionnaireResponse', resource);
+  }
+
+  /**
+   * All completed GAD-7 responses for a patient that the given organization
+   * authored, oldest first. This is the live query behind a share: it runs on
+   * every manifest poll, so an assessment A completes after minting the link
+   * shows up on B's next read without any further action.
+   */
+  async listGad7(input: {
+    patient: string;
+    sourceOrganization: string;
+    questionnaire?: string;
+  }): Promise<QuestionnaireResponse[]> {
+    // `author` has a stock search parameter, so the organization scoping is
+    // pushed into Aidbox rather than filtered in memory — the share never even
+    // reads another organization's assessments for this patient.
+    const page = await this.fhir.search<QuestionnaireResponse>('QuestionnaireResponse', [
+      ['subject', input.patient],
+      ['questionnaire', input.questionnaire ?? GAD7_QUESTIONNAIRE_URL],
+      ['status', 'completed'],
+      ['author', input.sourceOrganization],
+      // Newest first, then reversed below. The sort direction matters: this
+      // fetches one page, so past MAX_SHARED_RESPONSES the *oldest* assessments
+      // drop off rather than the newest — losing recent history would be the
+      // worse failure for a clinician reading a referral.
+      ['_sort', '-authored'],
+      ['_count', String(MAX_SHARED_RESPONSES)],
+    ]);
+
+    // Return oldest-first, the order the share presents them in.
+    return page.reverse();
+  }
+}
+
+/**
+ * Reduce renderer-produced items to the canonical shape, keeping only known
+ * GAD-7 linkIds and codes.
+ *
+ * The renderer submits what the Questionnaire declares, which is close to what
+ * we want but not identical: item order can differ, unanswered items may appear
+ * with an empty `answer`, and the `display` comes from whatever the terminology
+ * expansion returned. Rebuilding from `GAD7_ITEMS` means the stored resource is
+ * byte-identical to the API path's, and an unrecognised linkId or code is
+ * dropped rather than persisted — the browser does not get to widen the
+ * instrument.
+ */
+function normalizeItems(items: QuestionnaireResponseItem[]): QuestionnaireResponseItem[] {
+  const answers: Gad7Answer[] = [];
+  for (const item of items) {
+    const code = item.answer?.[0]?.valueCoding?.code;
+    if (code) answers.push({ linkId: item.linkId, code });
+  }
+  return buildItems(answers);
+}
+
+/** Build QuestionnaireResponse items from submitted answers, in questionnaire order. */
+function buildItems(answers: Gad7Answer[]): QuestionnaireResponseItem[] {
+  const byLinkId = new Map(answers.map((a) => [a.linkId, a.code]));
+
+  return GAD7_ITEMS.flatMap((defn) => {
+    const code = byLinkId.get(defn.linkId);
+    if (code === undefined) return [];
+
+    const scale = defn.scored ? GAD7_CHOICES : GAD7_DIFFICULTY_CHOICES;
+    const choice = scale.find((c) => c.code === code);
+    if (!choice) return [];
+
+    return [
+      {
+        linkId: defn.linkId,
+        text: defn.text,
+        answer: [
+          {
+            valueCoding: {
+              system: GAD7_ANSWER_SYSTEM,
+              code: choice.code,
+              display: choice.display,
+            },
+          },
+        ],
+      },
+    ];
+  });
+}
+
+/** Sum the seven scored items (0–21). Unanswered items count as 0. */
+export function computeGad7Total(items: QuestionnaireResponseItem[] | undefined): number {
+  if (!items) return 0;
+  let total = 0;
+  for (const item of items) {
+    if (!GAD7_SCORED_LINK_IDS.includes(item.linkId)) continue;
+    const code = item.answer?.[0]?.valueCoding?.code;
+    const choice = GAD7_CHOICES.find((c) => c.code === code);
+    if (choice) total += choice.score;
+  }
+  return total;
+}
+
+/** The stored total for a response, falling back to recomputing it from the items. */
+export function gad7TotalOf(response: QuestionnaireResponse): number {
+  const stored = response.extension?.find((e) => e.url === GAD7_SCORE_EXTENSION)?.valueDecimal;
+  return stored ?? computeGad7Total(response.item);
+}

--- a/aidbox-integrations/shared-assessment-link/src/services/fhir-client.ts
+++ b/aidbox-integrations/shared-assessment-link/src/services/fhir-client.ts
@@ -1,0 +1,78 @@
+import { AidboxClient, BasicAuthProvider } from '@health-samurai/aidbox-client';
+import type { AuthProvider } from '@health-samurai/aidbox-client';
+import type { Config } from '../types/config.ts';
+import type { Bundle } from '../types/fhir.ts';
+
+/**
+ * Thin wrapper over the official Aidbox TypeScript client
+ * (@health-samurai/aidbox-client). Uses Basic auth with the `share-client`
+ * registered in the init bundle.
+ *
+ * The client returns a `Result` (Ok | Err) rather than throwing on FHIR errors;
+ * we surface that as a thrown Error for create/update and as `null` for a
+ * missing read.
+ */
+export class FhirClient {
+  private readonly client: AidboxClient;
+
+  constructor(config: Config) {
+    // The client prepends "/fhir" itself, so baseUrl must be the bare host.
+    const baseUrl = config.aidbox.baseUrl;
+    // BasicAuthProvider satisfies AuthProvider at runtime; the cast bridges a
+    // typing quirk where AuthProvider.fetch demands the full global fetch type.
+    const auth = new BasicAuthProvider(
+      baseUrl,
+      config.aidbox.clientId,
+      config.aidbox.clientSecret
+    ) as unknown as AuthProvider;
+    this.client = new AidboxClient(baseUrl, auth);
+  }
+
+  /** Create a resource, letting Aidbox assign the id. */
+  async create<T>(resourceType: string, resource: object): Promise<T> {
+    const result = await this.client.create<T>({ type: resourceType, resource: resource as T });
+    if (result.isErr()) {
+      throw new Error(
+        `Aidbox create ${resourceType} failed: ${JSON.stringify(result.value.resource)}`
+      );
+    }
+    return result.value.resource;
+  }
+
+  /** Upsert a resource at a known id. */
+  async put<T>(resourceType: string, id: string, resource: object): Promise<T> {
+    const result = await this.client.update<T>({ type: resourceType, id, resource: resource as T });
+    if (result.isErr()) {
+      throw new Error(
+        `Aidbox update ${resourceType}/${id} failed: ${JSON.stringify(result.value.resource)}`
+      );
+    }
+    return result.value.resource;
+  }
+
+  /** Read a resource by id. Returns null if it does not exist. */
+  async read<T>(resourceType: string, id: string): Promise<T | null> {
+    const result = await this.client.read<T>({ type: resourceType, id });
+    if (result.isErr()) {
+      if (result.value.response.status === 404) return null;
+      throw new Error(
+        `Aidbox read ${resourceType}/${id} failed: ${JSON.stringify(result.value.resource)}`
+      );
+    }
+    return result.value.resource;
+  }
+
+  /** Search a resource type, returning the matched resources (entries unwrapped). */
+  async search<T>(resourceType: string, query: [string, string][]): Promise<T[]> {
+    const result = await this.client.searchType({ type: resourceType, query });
+    if (result.isErr()) {
+      throw new Error(
+        `Aidbox search ${resourceType} failed: ${JSON.stringify(result.value.resource)}`
+      );
+    }
+    const bundle = result.value.resource as Bundle<T>;
+    return (bundle.entry ?? [])
+      .map((e) => e.resource)
+      .filter((r): r is T => r !== undefined && r !== null);
+  }
+}

--- a/aidbox-integrations/shared-assessment-link/src/services/redaction.ts
+++ b/aidbox-integrations/shared-assessment-link/src/services/redaction.ts
@@ -1,0 +1,117 @@
+import type { QuestionnaireResponse, QuestionnaireResponseItem } from '../types/fhir.ts';
+import { GAD7_SCORED_LINK_IDS } from '../types/gad7.ts';
+import { GAD7_SCORE_EXTENSION, computeGad7Total, gad7TotalOf } from './assessment-service.ts';
+
+/**
+ * URL of the extension that records *that* an item was withheld.
+ *
+ * Silently dropping an item is worse than saying it was dropped: the recipient
+ * clinician cannot tell "the patient didn't answer" from "the sender wouldn't
+ * show me". So redaction replaces each hidden item with a marker carrying the
+ * item's linkId and text but no answer — the question stays visible, the
+ * response does not.
+ */
+export const REDACTED_EXTENSION = 'http://example.org/fhir/StructureDefinition/data-absent-reason';
+
+/** Value used for a withheld answer, mirroring FHIR's `masked` data-absent-reason. */
+export const REDACTED_REASON = 'masked';
+
+/** What a redaction pass actually removed, for the audit trail and the UI. */
+export interface RedactionSummary {
+  /** linkIds that were present in the source and got masked. */
+  redactedLinkIds: string[];
+  /** Whether the computed total score was withheld. */
+  scoreWithheld: boolean;
+}
+
+/**
+ * Apply a share's field-level policy to one QuestionnaireResponse.
+ *
+ * Two things happen, and the second is the subtle one:
+ *
+ *  1. Every item whose `linkId` is in `hiddenItems` loses its answer and gains a
+ *     `masked` data-absent-reason marker.
+ *  2. The total score is dropped unless the share explicitly permits it. A GAD-7
+ *     total is a sum of the seven items, so publishing the total alongside a
+ *     partially hidden set leaks information about what was hidden — with six of
+ *     seven items visible, the seventh is exactly `total - sum(visible)`. The
+ *     score therefore travels only when `shareScore` is on, and even then it is
+ *     recomputed from the *visible* items whenever anything scored was hidden, so
+ *     it can never act as an oracle for a masked answer.
+ */
+export function redactResponse(
+  response: QuestionnaireResponse,
+  policy: { hiddenItems?: string[]; shareScore?: boolean }
+): { resource: QuestionnaireResponse; summary: RedactionSummary } {
+  const hidden = new Set(policy.hiddenItems ?? []);
+  const redactedLinkIds: string[] = [];
+
+  /**
+   * Walk the item tree, masking anything the policy hides.
+   *
+   * Recursion matters even though the GAD-7 is flat: `item.item` is legal FHIR,
+   * and a redactor that only looked at the top level would silently pass a
+   * hidden answer through as soon as anyone added a grouped instrument. Masking
+   * a group masks its children with it — you cannot withhold a heading and
+   * still publish what was under it.
+   */
+  function walk(items: QuestionnaireResponseItem[]): QuestionnaireResponseItem[] {
+    return items.map((item) => {
+      if (hidden.has(item.linkId)) {
+        redactedLinkIds.push(item.linkId);
+        return maskItem(item);
+      }
+      if (item.item?.length) {
+        return { ...item, item: walk(item.item) };
+      }
+      return item;
+    });
+  }
+
+  const items = walk(response.item ?? []);
+
+  // Did we hide anything that feeds the total? If so, a stored total would be a
+  // back door to the masked answers, so any score we emit must be recomputed
+  // from what remains visible.
+  const hidScoredItem = redactedLinkIds.some((id) => GAD7_SCORED_LINK_IDS.includes(id));
+  const shareScore = policy.shareScore !== false;
+
+  const extension: QuestionnaireResponse['extension'] = [];
+  if (shareScore) {
+    const total = hidScoredItem ? computeGad7Total(items) : gad7TotalOf(response);
+    extension.push({ url: GAD7_SCORE_EXTENSION, valueDecimal: total });
+  }
+
+  const resource: QuestionnaireResponse = {
+    ...response,
+    item: items,
+    // Carry other extensions through untouched; only the score is policy-gated.
+    extension: [
+      ...extension,
+      ...(response.extension ?? []).filter((e) => e.url !== GAD7_SCORE_EXTENSION),
+    ],
+  };
+
+  return {
+    resource,
+    summary: { redactedLinkIds, scoreWithheld: !shareScore },
+  };
+}
+
+/**
+ * Strip an item's answers, leaving the question and a `masked` marker behind.
+ *
+ * Built as an allowlist — only `linkId` and `text` are copied — rather than by
+ * deleting `answer` from a clone. That is deliberate: anything not named here
+ * cannot survive, so nested `item[]` and any future answer field are dropped
+ * automatically instead of leaking through a field the redactor forgot about.
+ */
+function maskItem(item: QuestionnaireResponseItem): QuestionnaireResponseItem {
+  return {
+    linkId: item.linkId,
+    ...(item.text !== undefined ? { text: item.text } : {}),
+    // No `answer` and no child `item` — plus an explicit marker so the receiver
+    // renders "withheld by the sharing organization", not "no answer given".
+    extension: [{ url: REDACTED_EXTENSION, valueCode: REDACTED_REASON }],
+  };
+}

--- a/aidbox-integrations/shared-assessment-link/src/services/share-content.ts
+++ b/aidbox-integrations/shared-assessment-link/src/services/share-content.ts
@@ -1,0 +1,91 @@
+import type { AssessmentShareResource } from '../types/assessment-share-resource.ts';
+import type { Bundle, QuestionnaireResponse } from '../types/fhir.ts';
+import type { AssessmentService } from './assessment-service.ts';
+import type { ContentProvider } from './share-service.ts';
+import { redactResponse } from './redaction.ts';
+
+/** URL of the extension describing the share window on the outgoing bundle. */
+export const SHARE_WINDOW_EXTENSION =
+  'http://example.org/fhir/StructureDefinition/share-window';
+/** URL of the extension listing the items withheld from the outgoing bundle. */
+export const SHARE_REDACTION_EXTENSION =
+  'http://example.org/fhir/StructureDefinition/share-redaction';
+
+/**
+ * Builds what the recipient organization actually reads: a FHIR searchset Bundle
+ * of the sharing organization's GAD-7 responses for the patient, with the
+ * share's field policy applied.
+ *
+ * Called by the protocol engine on *every* manifest poll, which is what makes the
+ * share live. Two properties follow from that:
+ *
+ *   - an assessment Provider A completes after minting the link is simply picked
+ *     up by the next query — no re-mint, no notification plumbing;
+ *   - if A tightens `hiddenItems` later, the change applies retroactively to the
+ *     same link, because no unredacted copy was ever encrypted.
+ *
+ * The bundle is self-describing: it states the window it was produced under and
+ * which items were withheld, so the receiving clinician can see the shape of what
+ * they were and weren't given.
+ */
+export class ShareContentProvider implements ContentProvider {
+  constructor(private readonly assessments: AssessmentService) {}
+
+  async build(
+    share: AssessmentShareResource
+  ): Promise<{ bytes: string; responseCount: number }> {
+    const responses = await this.assessments.listGad7({
+      patient: share.patient,
+      sourceOrganization: share.sourceOrganization,
+      questionnaire: share.questionnaire,
+    });
+
+    const redactedLinkIds = new Set<string>();
+    let scoreWithheld = false;
+
+    const shared: QuestionnaireResponse[] = responses.map((response) => {
+      const { resource, summary } = redactResponse(response, {
+        hiddenItems: share.hiddenItems,
+        shareScore: share.shareScore,
+      });
+      summary.redactedLinkIds.forEach((id) => redactedLinkIds.add(id));
+      if (summary.scoreWithheld) scoreWithheld = true;
+      return resource;
+    });
+
+    const bundle: Bundle<QuestionnaireResponse> & {
+      extension: Array<Record<string, unknown>>;
+    } = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      timestamp: new Date().toISOString(),
+      total: shared.length,
+      // Tell the recipient the terms under which they're reading this, so the
+      // constraints travel with the data rather than living only on our server.
+      extension: [
+        {
+          url: SHARE_WINDOW_EXTENSION,
+          extension: [
+            { url: 'start', valueInstant: new Date(share.startsAt * 1000).toISOString() },
+            { url: 'end', valueInstant: new Date(share.endsAt * 1000).toISOString() },
+            { url: 'sharedBy', valueString: share.sourceOrganization },
+            { url: 'sharedWith', valueString: share.recipientDisplay ?? share.recipientOrganization },
+          ],
+        },
+        {
+          url: SHARE_REDACTION_EXTENSION,
+          extension: [
+            ...[...redactedLinkIds].sort().map((id) => ({ url: 'withheldItem', valueString: id })),
+            { url: 'scoreWithheld', valueBoolean: scoreWithheld },
+          ],
+        },
+      ],
+      // No `fullUrl`: FHIR requires it to be absolute, and the recipient has no
+      // access to this server's FHIR base anyway — the id on each resource is
+      // what identifies it. An absent optional field beats an invalid one.
+      entry: shared.map((resource) => ({ resource })),
+    };
+
+    return { bytes: JSON.stringify(bundle), responseCount: shared.length };
+  }
+}

--- a/aidbox-integrations/shared-assessment-link/src/services/share-service.ts
+++ b/aidbox-integrations/shared-assessment-link/src/services/share-service.ts
@@ -1,0 +1,320 @@
+import type { Config } from '../types/config.ts';
+import type { ManifestResponse, SHLPayload, SHLFileContentType } from '../types/shl.ts';
+import type {
+  AssessmentShareResource,
+  FileToken,
+} from '../types/assessment-share-resource.ts';
+import type { ShareStore } from './share-store.ts';
+import { encryptToJwe, generateShlKey } from '../utils/crypto.ts';
+import { encodeShlink } from '../utils/shl-encode.ts';
+
+const FHIR_CONTENT_TYPE: SHLFileContentType = 'application/fhir+json';
+
+/** Discriminated outcome of a manifest request, so the handler can pick the HTTP status. */
+export type ManifestResult =
+  | { kind: 'ok'; manifest: ManifestResponse }
+  | { kind: 'not-found' }
+  | { kind: 'passcode-required' }
+  | { kind: 'passcode-invalid'; remainingAttempts: number }
+  | { kind: 'rate-limited'; retryAfterSeconds: number };
+
+/** Discriminated outcome of a file (location) fetch. */
+export type FileResult =
+  | { kind: 'ok'; jwe: string }
+  | { kind: 'not-found' }
+  | { kind: 'gone' }; // expired token, or the share window closed
+
+/** Why a share is not currently readable. `open` means it resolves normally. */
+export type WindowState = 'not-yet-started' | 'open' | 'ended' | 'revoked';
+
+/**
+ * Builds the plaintext a share carries, on demand.
+ *
+ * The protocol engine below is deliberately ignorant of assessments: it asks the
+ * provider for bytes each time a manifest is resolved. That indirection is what
+ * makes the share *live* — a new assessment, or a change to what's hidden, shows
+ * up on the recipient's next poll with no re-minting.
+ */
+export interface ContentProvider {
+  build(share: AssessmentShareResource): Promise<{ bytes: string; responseCount: number }>;
+}
+
+/**
+ * The SMART Health Links protocol engine, specialised for *policy-based,
+ * time-bounded* shares.
+ *
+ * Where a snapshot-style SHL encrypts content once at mint time, a share here
+ * stores only a policy (patient, questionnaire, window, hidden items) and
+ * re-derives its content on every manifest poll through a `ContentProvider`.
+ * That single change is what delivers the use case:
+ *
+ *   - **live** — assessments Provider A completes after minting appear on B's
+ *     next poll, because the bundle is rebuilt from live data each time;
+ *   - **closable** — the window is checked at read time, so the end date closes
+ *     access automatically and an early revoke takes effect immediately. There
+ *     is no pre-encrypted copy sitting on the server to claw back;
+ *   - **redacted** — the provider applies A's field policy during every build,
+ *     so tightening what's shared applies retroactively to the same link.
+ *
+ * It also owns the protocol's security plumbing:
+ *   - the P (passcode) flag with a *lifetime* incorrect-attempt counter (→ 401
+ *     { remainingAttempts }, lock at zero), persisted so parallel guesses can't bypass it;
+ *   - short-lived `location` file tokens with an expiry (→ 410 Gone);
+ *   - per-share manifest poll throttling (→ 429 + Retry-After).
+ */
+export class ShareService {
+  private readonly store: ShareStore;
+  private readonly content: ContentProvider;
+
+  constructor(
+    private readonly config: Config,
+    deps: { store: ShareStore; content: ContentProvider }
+  ) {
+    this.store = deps.store;
+    this.content = deps.content;
+  }
+
+  /**
+   * Grant Provider B time-bounded access to Provider A's assessments for one
+   * patient, and mint the `shlink:` that carries it.
+   *
+   * Nothing is encrypted here — only the policy is written down.
+   */
+  async createShare(input: {
+    label: string;
+    sourceOrganization: string;
+    recipientOrganization: string;
+    recipientDisplay?: string;
+    patient: string;
+    questionnaire: string;
+    startsAt: number;
+    endsAt: number;
+    hiddenItems?: string[];
+    shareScore?: boolean;
+    passcode?: string;
+  }): Promise<{ shareId: string; shlink: string; payload: SHLPayload }> {
+    if (input.endsAt <= input.startsAt) {
+      throw new Error('Share end date must be after the start date');
+    }
+
+    const passcode = input.passcode?.trim() || undefined;
+
+    const share = await this.store.create({
+      key: generateShlKey(),
+      label: input.label,
+      sourceOrganization: input.sourceOrganization,
+      recipientOrganization: input.recipientOrganization,
+      recipientDisplay: input.recipientDisplay,
+      patient: input.patient,
+      questionnaire: input.questionnaire,
+      startsAt: input.startsAt,
+      endsAt: input.endsAt,
+      // Omit when nothing is hidden — FHIR rejects an empty array.
+      ...(input.hiddenItems?.length ? { hiddenItems: input.hiddenItems } : {}),
+      shareScore: input.shareScore !== false,
+      status: 'active',
+      ...(passcode
+        ? { passcode, remainingAttempts: this.config.shlPolicy.passcodeMaxAttempts }
+        : {}),
+    });
+
+    const payload = this.buildPayload(share);
+    return {
+      shareId: share.id!,
+      shlink: encodeShlink(payload, this.config.shl.viewerUrl),
+      payload,
+    };
+  }
+
+  /**
+   * Close a share before its end date. Provider A's override.
+   *
+   * Because content is built at read time, this is effective immediately: the
+   * next manifest poll resolves to `no-longer-valid`, and outstanding `location`
+   * URLs stop working too (getFile re-checks the window, returning 410 Gone).
+   */
+  async revokeShare(shareId: string): Promise<AssessmentShareResource | null> {
+    const share = await this.store.get(shareId);
+    if (!share) return null;
+    if (share.status === 'revoked') return share;
+
+    // Note we keep `fileTokens`: getFile() re-checks the window, so outstanding
+    // location URLs are already dead. Keeping them lets that check report a
+    // truthful 410 Gone ("this existed and is now closed") instead of a 404.
+    return this.store.save({
+      ...share,
+      status: 'revoked',
+      revokedAt: Math.floor(Date.now() / 1000),
+    });
+  }
+
+  /** Where a share sits relative to its window and its status, evaluated now. */
+  windowState(share: AssessmentShareResource, nowSeconds = Math.floor(Date.now() / 1000)): WindowState {
+    if (share.status === 'revoked') return 'revoked';
+    if (nowSeconds < share.startsAt) return 'not-yet-started';
+    if (nowSeconds >= share.endsAt) return 'ended';
+    return 'open';
+  }
+
+  /**
+   * Resolve a manifest request: enforce throttle, passcode and window, then build
+   * and encrypt the current content.
+   */
+  async getManifest(
+    shareId: string,
+    opts: { embeddedLengthMax?: number; passcode?: string; recipient?: string } = {}
+  ): Promise<ManifestResult> {
+    const share = await this.store.get(shareId);
+    if (!share) return { kind: 'not-found' };
+
+    // --- 429: throttle frequent polls of the same share ---
+    const nowMs = Date.now();
+    const minMs = this.config.shlPolicy.manifestMinIntervalSeconds * 1000;
+    if (share.lastManifestAtMs && nowMs - share.lastManifestAtMs < minMs) {
+      const retryAfterSeconds = Math.ceil((minMs - (nowMs - share.lastManifestAtMs)) / 1000);
+      return { kind: 'rate-limited', retryAfterSeconds: Math.max(1, retryAfterSeconds) };
+    }
+
+    // --- passcode (P flag) ---
+    if (share.passcode) {
+      if (!opts.passcode) return { kind: 'passcode-required' };
+      if (opts.passcode !== share.passcode) {
+        // Lifetime attempt counting: decrement and persist before responding, so
+        // parallel requests can't each spend the "last" attempt.
+        const remaining = Math.max(0, (share.remainingAttempts ?? 0) - 1);
+        await this.store.save({ ...share, remainingAttempts: remaining, lastManifestAtMs: nowMs });
+        return { kind: 'passcode-invalid', remainingAttempts: remaining };
+      }
+    }
+
+    // Record this (successfully authenticated) poll for throttling.
+    let current: AssessmentShareResource = { ...share, lastManifestAtMs: nowMs };
+
+    // A passcode-locked share (no attempts left) is no longer resolvable.
+    if (current.passcode && (current.remainingAttempts ?? 0) <= 0) {
+      await this.store.save(current);
+      return { kind: 'ok', manifest: { status: 'no-longer-valid', files: [] } };
+    }
+
+    // --- the sharing window ---
+    const state = this.windowState(current, Math.floor(nowMs / 1000));
+    if (state === 'ended' || state === 'revoked') {
+      // Closed for good: the end date passed, or A revoked early.
+      await this.store.save(current);
+      return { kind: 'ok', manifest: { status: 'no-longer-valid', files: [] } };
+    }
+    if (state === 'not-yet-started') {
+      // The grant exists but hasn't opened yet. `can-change` with no files is the
+      // spec's way of saying "nothing to read right now, come back".
+      await this.store.save(current);
+      return { kind: 'ok', manifest: { status: 'can-change', files: [] } };
+    }
+
+    // --- open: build the current content and encrypt it under the share key ---
+    const { bytes, responseCount } = await this.content.build(current);
+    const jwe = await encryptToJwe(bytes, current.key, FHIR_CONTENT_TYPE);
+
+    // Drop expired tokens on every poll, not just when minting a new one: each
+    // one carries a full JWE, so a stale token would otherwise be re-serialized
+    // into every save for the rest of the share's life.
+    const liveTokens = (current.fileTokens ?? []).filter(isLive);
+
+    current = {
+      ...current,
+      accessLog: [
+        ...(current.accessLog ?? []),
+        { atMs: nowMs, recipient: opts.recipient ?? 'unknown', responseCount },
+      ].slice(-50), // keep the log bounded
+      // Assign only when non-empty: FHIR rejects an empty array outright, and the
+      // common (embedded) path mints no token at all.
+      ...(liveTokens.length ? { fileTokens: liveTokens } : { fileTokens: undefined }),
+    };
+
+    // Embed if the receiver allows it, else hand back a short-lived location URL.
+    const canEmbed = opts.embeddedLengthMax === undefined || jwe.length <= opts.embeddedLengthMax;
+
+    let manifest: ManifestResponse;
+    if (canEmbed) {
+      manifest = {
+        // Always `can-change`: the window is open, so new assessments may still
+        // appear. A share is never `finalized` — it goes straight to
+        // `no-longer-valid` when the window closes.
+        status: 'can-change',
+        files: [{ contentType: FHIR_CONTENT_TYPE, embedded: jwe }],
+      };
+    } else {
+      // Freeze this exact ciphertext against the token: a `location` fetch must
+      // return the bytes this manifest described, not a newer rebuild.
+      const fileToken = this.mintFileToken(current.id!, jwe);
+      current = { ...current, fileTokens: [...liveTokens, fileToken] };
+      manifest = {
+        status: 'can-change',
+        files: [
+          {
+            contentType: FHIR_CONTENT_TYPE,
+            location: `${this.config.shl.publicBaseUrl}/file/${fileToken.token}`,
+          },
+        ],
+      };
+    }
+
+    await this.store.save(current);
+    return { kind: 'ok', manifest };
+  }
+
+  /**
+   * Resolve a `location` file fetch by its short-lived token.
+   * Tokens embed the share id (`<shareId>~<random>`) so we can look up the share
+   * directly without a custom search parameter.
+   */
+  async getFile(token: string): Promise<FileResult> {
+    const shareId = token.split('~')[0];
+    if (!shareId) return { kind: 'not-found' };
+
+    const share = await this.store.get(shareId);
+    if (!share) return { kind: 'not-found' };
+
+    const entry = (share.fileTokens ?? []).find((t) => t.token === token);
+    if (!entry) return { kind: 'not-found' };
+
+    // Both gates apply: the token's own TTL, and the share window — revoking a
+    // share has to invalidate location URLs it already handed out.
+    if (Date.now() > entry.expiresAtMs || this.windowState(share) !== 'open') {
+      return { kind: 'gone' };
+    }
+    return { kind: 'ok', jwe: entry.jwe };
+  }
+
+  // --- internals -----------------------------------------------------------
+
+  private mintFileToken(shareId: string, jwe: string): FileToken {
+    return {
+      // <shareId>~<random> — the prefix lets getFile() find the share without a search param.
+      token: `${shareId}~${generateShlKey()}`,
+      expiresAtMs: Date.now() + this.config.shlPolicy.fileTokenTtlSeconds * 1000,
+      jwe,
+    };
+  }
+
+  buildPayload(share: AssessmentShareResource): SHLPayload {
+    return {
+      url: `${this.config.shl.publicBaseUrl}/manifest/${share.id}`,
+      key: share.key,
+      // The sharing end date *is* the link's expiry, so a conformant receiver can
+      // see the window without resolving the manifest.
+      exp: share.endsAt,
+      // L: long-term — contents evolve as A completes assessments. P when a passcode is set.
+      flag: share.passcode ? 'LP' : 'L',
+      label: share.label,
+      v: 1,
+    };
+  }
+
+  buildShlinkUri(share: AssessmentShareResource): string {
+    return encodeShlink(this.buildPayload(share), this.config.shl.viewerUrl);
+  }
+}
+
+function isLive(token: FileToken): boolean {
+  return token.expiresAtMs > Date.now();
+}

--- a/aidbox-integrations/shared-assessment-link/src/services/share-store.ts
+++ b/aidbox-integrations/shared-assessment-link/src/services/share-store.ts
@@ -1,0 +1,33 @@
+import type { FhirClient } from './fhir-client.ts';
+import type { AssessmentShareResource } from '../types/assessment-share-resource.ts';
+
+/** Persistence for the AssessmentShare custom resource. */
+export class ShareStore {
+  constructor(private readonly fhir: FhirClient) {}
+
+  create(
+    resource: Omit<AssessmentShareResource, 'resourceType' | 'id'>
+  ): Promise<AssessmentShareResource> {
+    return this.fhir.create<AssessmentShareResource>('AssessmentShare', {
+      resourceType: 'AssessmentShare',
+      ...resource,
+    });
+  }
+
+  get(id: string): Promise<AssessmentShareResource | null> {
+    return this.fhir.read<AssessmentShareResource>('AssessmentShare', id);
+  }
+
+  save(resource: AssessmentShareResource): Promise<AssessmentShareResource> {
+    if (!resource.id) throw new Error('Cannot save AssessmentShare without id');
+    return this.fhir.put<AssessmentShareResource>('AssessmentShare', resource.id, resource);
+  }
+
+  /** All shares, newest first — the sharing organization's dashboard view. */
+  list(): Promise<AssessmentShareResource[]> {
+    return this.fhir.search<AssessmentShareResource>('AssessmentShare', [
+      ['_sort', '-lastUpdated'],
+      ['_count', '50'],
+    ]);
+  }
+}

--- a/aidbox-integrations/shared-assessment-link/src/types/assessment-share-resource.ts
+++ b/aidbox-integrations/shared-assessment-link/src/types/assessment-share-resource.ts
@@ -1,0 +1,121 @@
+/**
+ * Custom Aidbox resource that persists one *assessment share* — the grant that
+ * lets Provider Organization B read Provider Organization A's assessments for
+ * one patient, within a time window and with selected items hidden.
+ *
+ * Registered as a first-class resource type via the init bundle. This is the
+ * server-side record behind a `shlink:`; the receiver never sees it directly.
+ *
+ * The key difference from a snapshot-style SHL: nothing is encrypted at mint
+ * time. The share stores a *policy* (who, which patient, which window, which
+ * items), and every manifest poll re-runs that policy against live data. That
+ * is what makes "B sees new assessments as A completes them" work, and what
+ * makes revocation immediate — there is no pre-encrypted copy to claw back.
+ *
+ * Security note: `key` is persisted so the manifest can encrypt a freshly built
+ * bundle on each poll. In production you would avoid long-term key storage; see
+ * the README's "Notes & scope".
+ */
+
+/** A short-lived, manifest-issued handle to the encrypted bundle (the SHL `location` URL). */
+export interface FileToken {
+  /** Random opaque token used in the file URL, of the form `<shareId>~<random>`. */
+  token: string;
+  /** Epoch-ms after which the token is dead (spec: <= 1 hour). */
+  expiresAtMs: number;
+  /**
+   * The JWE this token was minted for. A `location` fetch must return exactly
+   * the bytes the manifest described, so we freeze the ciphertext per token
+   * rather than rebuilding it (which would produce a different, possibly newer,
+   * bundle than the manifest advertised).
+   */
+  jwe: string;
+}
+
+/** Why a share stopped resolving. Kept for the audit trail. */
+export type ShareStatus = 'active' | 'revoked';
+
+export interface AssessmentShareResource {
+  resourceType: 'AssessmentShare';
+  id?: string;
+  /** Content-encryption key (43-char base64url of 32 bytes). */
+  key: string;
+  /** Human label surfaced in the shlink: payload, e.g. "GAD-7 assessments for Jane Roe". */
+  label: string;
+
+  // --- the parties -------------------------------------------------------
+  /** The sharing (source) organization — Provider A. `Organization/<id>`. */
+  sourceOrganization: string;
+  /** The receiving organization — Provider B. `Organization/<id>`. */
+  recipientOrganization: string;
+  /** Display name of the recipient org, so the viewer can name it without a lookup. */
+  recipientDisplay?: string;
+
+  // --- what is shared ----------------------------------------------------
+  /** The patient whose assessments are shared. `Patient/<id>`. */
+  patient: string;
+  /**
+   * Canonical URL of the Questionnaire whose responses are in scope
+   * (e.g. the GAD-7). A share covers one instrument, not the whole chart.
+   */
+  questionnaire: string;
+
+  // --- the time window ---------------------------------------------------
+  /** Start of the sharing window, epoch seconds. Before it, the link is not yet live. */
+  startsAt: number;
+  /** End of the sharing window, epoch seconds. After it, the link closes automatically. */
+  endsAt: number;
+
+  // --- field-level redaction --------------------------------------------
+  /**
+   * `linkId`s of the questionnaire items Provider A chose NOT to share. Items
+   * listed here are stripped from every response before encryption, and the
+   * omission is recorded in the outgoing bundle so B can see that something was
+   * withheld rather than silently missing. Empty/absent means share everything.
+   */
+  hiddenItems?: string[];
+  /**
+   * Whether the computed total score may be shared. A GAD-7 total is derivable
+   * from the items, so hiding items but keeping the score can leak them back;
+   * this flag lets A suppress the score explicitly.
+   */
+  shareScore?: boolean;
+
+  // --- lifecycle ---------------------------------------------------------
+  /** `active` until Provider A revokes it early. */
+  status: ShareStatus;
+  /** When A revoked the share, epoch seconds. Set only when status is `revoked`. */
+  revokedAt?: number;
+
+  // --- passcode (P flag) -------------------------------------------------
+  /** Passcode required to resolve the manifest, if the P flag is set. */
+  passcode?: string;
+  /** Remaining incorrect-passcode attempts over the share's whole lifetime. */
+  remainingAttempts?: number;
+
+  // --- location file tokens (short-lived `location` URLs) ----------------
+  /** Active file tokens minted by manifest requests. */
+  fileTokens?: FileToken[];
+
+  // --- manifest poll throttle (429 / Retry-After) -----------------------
+  /** Epoch-ms of the most recent manifest request, for rate-limiting. */
+  lastManifestAtMs?: number;
+
+  // --- access audit ------------------------------------------------------
+  /**
+   * One entry per resolved manifest poll. Provider A can see when B actually
+   * looked, and how many assessments were visible at that moment — the
+   * accountability half of a time-bounded grant.
+   */
+  accessLog?: AccessLogEntry[];
+}
+
+/** A single successful read of the share by the recipient. */
+export interface AccessLogEntry {
+  /** Epoch-ms of the poll. */
+  atMs: number;
+  /** The `recipient` string the receiver sent in the manifest request body. */
+  recipient: string;
+  /** How many QuestionnaireResponses were visible at that moment. */
+  responseCount: number;
+}

--- a/aidbox-integrations/shared-assessment-link/src/types/config.ts
+++ b/aidbox-integrations/shared-assessment-link/src/types/config.ts
@@ -1,0 +1,78 @@
+export interface Config {
+  aidbox: {
+    baseUrl: string;
+    clientId: string;
+    clientSecret: string;
+  };
+  shl: {
+    /** Public base URL of this app as reachable by the SHL receiver (used to build manifest/file URLs). */
+    publicBaseUrl: string;
+    /** Optional viewer URL prepended to the shlink: payload. Must end with '#'. Empty for a bare shlink:. */
+    viewerUrl: string;
+  };
+  share: {
+    /**
+     * The organization this deployment shares *as* — Provider A. Assessments are
+     * scoped to those it authored, so a share never exposes another
+     * organization's data about the same patient.
+     */
+    sourceOrganization: string;
+    /** Default length of a sharing window, in days, when the caller gives no end date. */
+    defaultWindowDays: number;
+  };
+  shlPolicy: {
+    /** Lifetime incorrect-passcode attempts allowed before a share locks (P flag). */
+    passcodeMaxAttempts: number;
+    /** Lifetime of a manifest-issued `location` URL, in seconds (spec: <= 3600). */
+    fileTokenTtlSeconds: number;
+    /** Minimum seconds between manifest requests for one share before 429. */
+    manifestMinIntervalSeconds: number;
+  };
+  server: {
+    port: number;
+  };
+}
+
+export function loadConfig(): Config {
+  const requiredEnvVars = [
+    'AIDBOX_BASE_URL',
+    'AIDBOX_CLIENT_ID',
+    'AIDBOX_CLIENT_SECRET',
+    'SHL_PUBLIC_BASE_URL',
+  ];
+
+  for (const envVar of requiredEnvVars) {
+    if (!process.env[envVar]) {
+      throw new Error(`Missing required environment variable: ${envVar}`);
+    }
+  }
+
+  return {
+    aidbox: {
+      // The Aidbox client prepends "/fhir" itself — pass the bare host here.
+      baseUrl: process.env.AIDBOX_BASE_URL!.replace(/\/fhir\/?$/, '').replace(/\/$/, ''),
+      clientId: process.env.AIDBOX_CLIENT_ID!,
+      clientSecret: process.env.AIDBOX_CLIENT_SECRET!,
+    },
+    shl: {
+      publicBaseUrl: process.env.SHL_PUBLIC_BASE_URL!.replace(/\/$/, ''),
+      viewerUrl: process.env.SHL_VIEWER_URL || '',
+    },
+    share: {
+      sourceOrganization:
+        process.env.SHARE_SOURCE_ORGANIZATION || 'Organization/provider-a',
+      defaultWindowDays: parseInt(process.env.SHARE_DEFAULT_WINDOW_DAYS || '30', 10),
+    },
+    shlPolicy: {
+      passcodeMaxAttempts: parseInt(process.env.SHL_PASSCODE_MAX_ATTEMPTS || '5', 10),
+      fileTokenTtlSeconds: parseInt(process.env.SHL_FILE_TOKEN_TTL_SECONDS || '60', 10),
+      manifestMinIntervalSeconds: parseInt(
+        process.env.SHL_MANIFEST_MIN_INTERVAL_SECONDS || '1',
+        10
+      ),
+    },
+    server: {
+      port: parseInt(process.env.PORT || '3000', 10),
+    },
+  };
+}

--- a/aidbox-integrations/shared-assessment-link/src/types/fhir.ts
+++ b/aidbox-integrations/shared-assessment-link/src/types/fhir.ts
@@ -1,0 +1,72 @@
+/**
+ * Minimal structural types for the FHIR resources this example touches.
+ * Only the fields the app reads or writes are modelled — enough for type safety
+ * without pulling in a full generated FHIR type package.
+ */
+
+export interface Coding {
+  system?: string;
+  code?: string;
+  display?: string;
+}
+
+export interface Reference {
+  reference?: string;
+  display?: string;
+}
+
+/** One answer on a QuestionnaireResponse item. */
+export interface QuestionnaireResponseAnswer {
+  valueCoding?: Coding;
+  valueString?: string;
+  valueInteger?: number;
+  valueBoolean?: boolean;
+  valueDecimal?: number;
+}
+
+/** One item on a QuestionnaireResponse — the unit of field-level redaction. */
+export interface QuestionnaireResponseItem {
+  linkId: string;
+  text?: string;
+  answer?: QuestionnaireResponseAnswer[];
+  item?: QuestionnaireResponseItem[];
+  /** Used to mark a withheld item with a `masked` data-absent-reason. */
+  extension?: Array<{ url: string; valueCode?: string }>;
+}
+
+export interface QuestionnaireResponse {
+  resourceType: 'QuestionnaireResponse';
+  id?: string;
+  meta?: { lastUpdated?: string; versionId?: string };
+  questionnaire?: string;
+  status?: 'in-progress' | 'completed' | 'amended' | 'entered-in-error' | 'stopped';
+  subject?: Reference;
+  authored?: string;
+  /**
+   * Who recorded the answers — how a share scopes to Provider A's own data.
+   *
+   * `author` rather than `source`: FHIR restricts `source` to a *person*
+   * (Patient | Practitioner | PractitionerRole | RelatedPerson), whereas `author`
+   * admits an Organization. The spec is explicit that "QuestionnaireResponses
+   * authored by other collections of people must use Organization".
+   */
+  author?: Reference;
+  item?: QuestionnaireResponseItem[];
+  extension?: Array<{ url: string; valueDecimal?: number; valueString?: string }>;
+}
+
+export interface Bundle<T = unknown> {
+  resourceType: 'Bundle';
+  id?: string;
+  type: string;
+  timestamp?: string;
+  total?: number;
+  entry?: Array<{ fullUrl?: string; resource?: T }>;
+}
+
+export interface Patient {
+  resourceType: 'Patient';
+  id?: string;
+  name?: Array<{ given?: string[]; family?: string; text?: string }>;
+  birthDate?: string;
+}

--- a/aidbox-integrations/shared-assessment-link/src/types/gad7.ts
+++ b/aidbox-integrations/shared-assessment-link/src/types/gad7.ts
@@ -1,0 +1,64 @@
+/**
+ * The GAD-7 (Generalized Anxiety Disorder 7-item scale) as used by this example.
+ *
+ * Seven items, each answered on the same 0–3 frequency scale, plus a
+ * functional-impairment item (`difficulty`) that is *not* part of the score.
+ * The total (0–21) bands into minimal / mild / moderate / severe anxiety.
+ *
+ * The `linkId`s here are the unit of Provider A's field-level redaction: when A
+ * hides an item, it hides `gad7-q1`…`gad7-q8` by linkId, which is what the
+ * share stores and what the redactor strips.
+ */
+
+export const GAD7_QUESTIONNAIRE_URL = 'http://example.org/fhir/Questionnaire/gad7';
+/** Resource id of the Questionnaire the init bundle provisions. */
+export const GAD7_QUESTIONNAIRE_ID = 'gad7';
+export const GAD7_ANSWER_SYSTEM = 'http://example.org/fhir/CodeSystem/gad7-frequency';
+
+/** The shared 0–3 frequency scale every scored GAD-7 item uses. */
+export const GAD7_CHOICES = [
+  { code: 'not-at-all', display: 'Not at all', score: 0 },
+  { code: 'several-days', display: 'Several days', score: 1 },
+  { code: 'more-than-half', display: 'More than half the days', score: 2 },
+  { code: 'nearly-every-day', display: 'Nearly every day', score: 3 },
+] as const;
+
+/**
+ * The eight items in presentation order. Q1–Q7 are the scored scale; Q8 is the
+ * standard functional-impairment follow-up, kept separate from the total.
+ *
+ * `scored` marks the seven that feed the 0–21 total; the impairment item does not.
+ */
+export const GAD7_ITEMS = [
+  { linkId: 'gad7-q1', text: 'Feeling nervous, anxious, or on edge', scored: true },
+  { linkId: 'gad7-q2', text: 'Not being able to stop or control worrying', scored: true },
+  { linkId: 'gad7-q3', text: 'Worrying too much about different things', scored: true },
+  { linkId: 'gad7-q4', text: 'Trouble relaxing', scored: true },
+  { linkId: 'gad7-q5', text: "Being so restless that it's hard to sit still", scored: true },
+  { linkId: 'gad7-q6', text: 'Becoming easily annoyed or irritable', scored: true },
+  { linkId: 'gad7-q7', text: 'Feeling afraid as if something awful might happen', scored: true },
+  {
+    linkId: 'gad7-q8',
+    text: 'How difficult have these problems made it for you to do your work, take care of things at home, or get along with other people?',
+    scored: false,
+  },
+] as const;
+
+/** The distinct answer scale for the impairment item (Q8). */
+export const GAD7_DIFFICULTY_CHOICES = [
+  { code: 'not-difficult', display: 'Not difficult at all', score: 0 },
+  { code: 'somewhat-difficult', display: 'Somewhat difficult', score: 1 },
+  { code: 'very-difficult', display: 'Very difficult', score: 2 },
+  { code: 'extremely-difficult', display: 'Extremely difficult', score: 3 },
+] as const;
+
+/**
+ * The seven scored linkIds, for score computation and the leak check.
+ *
+ * Typed as `string[]` rather than the literal union `GAD7_ITEMS` would infer:
+ * callers test *arbitrary* linkIds against it (a hidden item from a share, an
+ * item off a submitted response), and a narrow union would reject those.
+ */
+export const GAD7_SCORED_LINK_IDS: string[] = GAD7_ITEMS.filter((i) => i.scored).map(
+  (i) => i.linkId
+);

--- a/aidbox-integrations/shared-assessment-link/src/types/operation.ts
+++ b/aidbox-integrations/shared-assessment-link/src/types/operation.ts
@@ -1,0 +1,26 @@
+/**
+ * Shape of the request Aidbox sends to an App endpoint when one of its
+ * configured `operations` is triggered.
+ */
+export interface AidboxOperationRequest {
+  type: string;
+  operation: {
+    id: string;
+  };
+  request: {
+    // For POST operations, the parsed request body (e.g. a FHIR Parameters or the SHL manifest request body).
+    resource?: unknown;
+    // Path placeholders declared in App.operations[].path, e.g. { shareId } or { fileId }.
+    'route-params': Record<string, string>;
+    // Query string params.
+    params?: Record<string, string>;
+    headers: Record<string, string>;
+  };
+}
+
+/** Body of a SMART Health Links manifest request (POST to the manifest URL). */
+export interface ManifestRequestBody {
+  recipient: string;
+  passcode?: string;
+  embeddedLengthMax?: number;
+}

--- a/aidbox-integrations/shared-assessment-link/src/types/shl.ts
+++ b/aidbox-integrations/shared-assessment-link/src/types/shl.ts
@@ -1,0 +1,47 @@
+/**
+ * SMART Health Links domain types.
+ * Spec: https://hl7.org/fhir/uv/smart-health-cards-and-links/STU1/links-specification.html
+ */
+
+/** The JSON payload that gets base64url-encoded into a `shlink:` URI. */
+export interface SHLPayload {
+  /** Manifest URL for this SMART Health Link. */
+  url: string;
+  /** 43-char base64url of 32 random bytes — the AES key all files are encrypted under. */
+  key: string;
+  /** Optional expiration time, epoch seconds. Mirrors the share's end date. */
+  exp?: number;
+  /** Single-char flags concatenated alphabetically: L (long-term), P (passcode), U (direct file). */
+  flag?: string;
+  /** Short (<=80 char) human description of the data. */
+  label?: string;
+  /** Protocol version (defaults to 1). */
+  v?: number;
+}
+
+/** Content types the SHL protocol uses for manifest files. */
+export type SHLFileContentType =
+  | 'application/smart-health-card'
+  | 'application/fhir+json'
+  | 'application/smart-api-access';
+
+/** One entry in the manifest `files` array. */
+export interface ManifestFile {
+  contentType: SHLFileContentType;
+  /** Short-lived, single-use URL to fetch the JWE. Present unless `embedded` is used. */
+  location?: string;
+  /** The JWE compact serialization inlined directly. Present when small enough. */
+  embedded?: string;
+}
+
+/** Manifest response body returned to the SHL receiver. */
+export interface ManifestResponse {
+  /**
+   * Lifecycle status of the manifest contents:
+   * - can-change: the share window is open, so new assessments may still appear
+   * - finalized: contents are stable (not used here — a share is live until it closes)
+   * - no-longer-valid: the window has closed (end date passed, or revoked early)
+   */
+  status: 'can-change' | 'finalized' | 'no-longer-valid';
+  files: ManifestFile[];
+}

--- a/aidbox-integrations/shared-assessment-link/src/utils/crypto.ts
+++ b/aidbox-integrations/shared-assessment-link/src/utils/crypto.ts
@@ -1,0 +1,41 @@
+import { CompactEncrypt, compactDecrypt, base64url } from 'jose';
+
+/**
+ * Crypto helpers for SMART Health Links.
+ *
+ * Every file shared through an SHL is encrypted with AES-256-GCM using a single
+ * 32-byte key that travels inside the `shlink:` payload. Whoever holds that key
+ * (Provider Organization B, who received the link) can decrypt; nobody else can.
+ * The server stores only ciphertext, and only ever for the lifetime of a
+ * short-lived file token — the shared bundle is rebuilt from live data on each
+ * manifest poll rather than sitting encrypted at rest.
+ */
+
+/** Generate a fresh 32-byte content-encryption key, base64url-encoded (43 chars). */
+export function generateShlKey(): string {
+  const raw = new Uint8Array(32);
+  crypto.getRandomValues(raw);
+  return base64url.encode(raw);
+}
+
+/**
+ * Encrypt a UTF-8 string into a JWE compact serialization using direct (`dir`)
+ * AES-256-GCM encryption. `cty` records the decrypted payload's content type per spec.
+ */
+export async function encryptToJwe(
+  plaintext: string,
+  keyB64url: string,
+  contentType: string
+): Promise<string> {
+  const key = base64url.decode(keyB64url);
+  return new CompactEncrypt(new TextEncoder().encode(plaintext))
+    .setProtectedHeader({ alg: 'dir', enc: 'A256GCM', cty: contentType })
+    .encrypt(key);
+}
+
+/** Decrypt a JWE compact serialization back to its UTF-8 plaintext. */
+export async function decryptJwe(jwe: string, keyB64url: string): Promise<string> {
+  const key = base64url.decode(keyB64url);
+  const { plaintext } = await compactDecrypt(jwe, key);
+  return new TextDecoder().decode(plaintext);
+}

--- a/aidbox-integrations/shared-assessment-link/src/utils/shl-encode.ts
+++ b/aidbox-integrations/shared-assessment-link/src/utils/shl-encode.ts
@@ -1,0 +1,30 @@
+import { base64url } from 'jose';
+import type { SHLPayload } from '../types/shl.ts';
+
+/**
+ * Encode an SHL payload into a `shlink:` URI.
+ *
+ *   1. minify the JSON payload
+ *   2. base64url-encode it
+ *   3. prefix with `shlink:/`
+ *   4. optionally prepend a viewer URL ending in `#`
+ *
+ * e.g. https://viewer.example.org#shlink:/eyJ1cmwiOiI...
+ */
+export function encodeShlink(payload: SHLPayload, viewerUrl = ''): string {
+  const json = JSON.stringify(payload);
+  const encoded = base64url.encode(new TextEncoder().encode(json));
+  return `${viewerUrl}shlink:/${encoded}`;
+}
+
+/** Decode a `shlink:` URI (with or without a viewer prefix) back to its payload. */
+export function decodeShlink(shlink: string): SHLPayload {
+  const marker = 'shlink:/';
+  const idx = shlink.indexOf(marker);
+  if (idx === -1) {
+    throw new Error('Not a shlink: URI');
+  }
+  const encoded = shlink.slice(idx + marker.length);
+  const json = new TextDecoder().decode(base64url.decode(encoded));
+  return JSON.parse(json) as SHLPayload;
+}

--- a/aidbox-integrations/shared-assessment-link/tsconfig.json
+++ b/aidbox-integrations/shared-assessment-link/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "types": ["@types/bun"],
+
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "resolveJsonModule": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/aidbox-integrations/smart-health-link/README.md
+++ b/aidbox-integrations/smart-health-link/README.md
@@ -7,6 +7,8 @@ runtimes: [Bun]
 
 A small TypeScript ([Bun](https://bun.sh)) implementation of [SMART Health Links (SHL)](https://hl7.org/fhir/uv/smart-health-cards-and-links/STU1/links-specification.html) on Aidbox. It shares the result of a slow **real-time eligibility (RTE)** check with a client that has no account, and keeps that result private to the client.
 
+> **There are two SHL examples in this repo.** This one shares a **snapshot**: one finished result, encrypted at mint time — the shorter read if you want the bare protocol. [`shared-assessment-link`](../shared-assessment-link/) shares a **live, policy-driven view** instead, rebuilt and re-redacted on every read, which is what a time window, automatic expiry, and immediate revocation require.
+
 ## Use case
 
 Someone is thinking about signing up. First they want to know: *am I covered, and what will it cost me?* They have no account yet, so nothing can log them in. The answer also takes a few seconds, because the app has to check coverage with the payer.


### PR DESCRIPTION
A second SMART Health Links example, next to the existing [`smart-health-link`](aidbox-integrations/smart-health-link/). Where that one shares a **fixed snapshot**, this one shares a **live, policy-driven view** — the two sit at opposite ends of the same tradeoff, and each README now points at the other.

## Use case

A behavioral-health practice refers a patient to a psychiatry group and wants to share the patient's GAD-7 history — for a fixed window, with certain questions held back, and with the option to close the sharing early if the referral falls through.

## The design decision

**Nothing is encrypted at mint time.** An `AssessmentShare` custom resource stores only a *policy* (patient, questionnaire, window, hidden items). Every manifest poll re-queries live data, re-applies the redaction, and encrypts fresh. Four properties follow from that one choice:

| Requirement | Why it holds |
|---|---|
| New assessments appear automatically | Each read re-runs the query |
| The end date closes access on its own | The window is checked at read time — no scheduled job |
| An early revoke takes effect at once | There is no pre-encrypted copy to claw back |
| Tightening what's shared applies retroactively | Redaction runs on every read |

## Two details worth reading the code for

**Withheld, not missing.** A hidden item keeps its `linkId` and question text but loses its answer and gains a `masked` data-absent-reason — so a receiving clinician can tell "the sender withheld this" from "the patient didn't answer". Redaction runs server-side *before* encryption, so the withheld answer is never inside the JWE.

**The score is a back door.** A GAD-7 total is the sum of its seven items, so publishing it beside a hidden item leaks that answer by subtraction. The score is either omitted entirely or recomputed from the *visible* items only.

## What the README covers

Beyond the walkthrough, it compares **four ways to split this work between the FHIR server and the app** — app-side filtering (what this example does), `\$extract` into discrete resources, a pre-built Bundle, and LBAC — with diagrams showing where enforcement lives in each, and the tradeoffs of each.

## Implementation notes

- The GAD-7 intake form is rendered by [`@formbox/renderer`](https://github.com/HealthSamurai/formbox-renderer) from the `Questionnaire` stored in Aidbox, as [HealthSamurai/phr](https://github.com/HealthSamurai/phr) does. `Bun.build()` compiles that React island at server startup, so there is still **no separate build step** — `bun src/server.ts` does everything. The other three UI tabs stay plain no-build HTML.
- `QuestionnaireResponse.author` (not `.source`) carries the authoring organization: FHIR restricts `source` to a person, and `author` has a stock search parameter, so the organization scoping is pushed into the Aidbox query rather than filtered in memory.
- Published on port **3100** so it doesn't collide with the sibling example's app port.

## Verified

Run end to end from a clean checkout: `bun install`, `tsc --noEmit` and eslint clean; `docker compose up --build` healthy; the form fills and submits in a real browser (score correctly counts only the 7 scored items); a share resolves, decrypts client-side, picks up a newly added assessment on the next poll, and closes on both revoke and window expiry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)