### PR TITLE
healthclaw-guardrails: agent guardrails in front of Aidbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A collection of examples on top of Aidbox FHIR platform
 - [FHIR R5 Topic-Based Subscriptions](aidbox-integrations/r5-subscriptions/)
 - [SMART Health Links for eligibility results](aidbox-integrations/smart-health-link/)
 - [SMART Health Links: time-bounded assessment sharing between providers](aidbox-integrations/shared-assessment-link/)
+- [Guardrails for AI agents: redaction, audit, step-up and human-in-the-loop in front of Aidbox](aidbox-integrations/healthclaw-guardrails/)
 
 ## Aidbox Features
 

--- a/aidbox-integrations/healthclaw-guardrails/.env.example
+++ b/aidbox-integrations/healthclaw-guardrails/.env.example
@@ -1,0 +1,43 @@
+# Copy to .env before `docker compose up -d`.
+
+# OPTIONAL, and COMMENTED OUT ON PURPOSE. Aidbox has to be activated before
+# it serves any route at all — until it is, every request including /health
+# redirects to "Log in to activate Aidbox", which looks like a network fault
+# rather than a licence one. Two ways to clear it:
+#
+#   leave this commented  `docker compose up -d`, then open
+#                         http://localhost:8080 and click "Continue with
+#                         Aidbox account". Compose is waiting on Aidbox's
+#                         health check and starts the proxy once you are in.
+#   uncomment with a key  free self-hosted licence from https://aidbox.app
+#                         (account -> licenses). Unattended runs need this.
+#
+# Do not leave it uncommented and empty. Aidbox rejects an empty licence
+# harder than a missing one — it refuses to boot with "License is invalid
+# ... not in correct format". Unset and empty are different states here.
+# BOX_LICENSE=
+
+# macOS holds port 5000 for AirPlay Receiver (ControlCenter), so `up` fails
+# with "address already in use". Uncomment to move the host port; the URLs in
+# README.md then use 5099 instead of 5000.
+# HEALTHCLAW_PORT=5099
+
+# Signs step-up tokens. Any value works locally; it must be a real secret in
+# any deployment that is not this demo. Generate one with:
+#   openssl rand -hex 32
+STEP_UP_SECRET=dev-only-change-me
+
+# Authenticates callers to the MCP server. It REFUSES TO START without one
+# rather than serving an unauthenticated tool endpoint, so this is required,
+# not optional. Generate one with:
+#   openssl rand -hex 32
+MCP_AUTH_TOKEN=dev-only-change-me
+
+# The credential the guardrail proxy presents to Aidbox. Must match the
+# Client secret in init-bundle/bundle.json. Change both together.
+FHIR_UPSTREAM_CLIENT_SECRET=healthclaw-secret
+
+# Aidbox's root client, used by the walkthrough to read AROUND the proxy and
+# show what the record actually contains. An agent never gets this.
+AIDBOX_CLIENT=root
+AIDBOX_SECRET=qNbQS6sw82

--- a/aidbox-integrations/healthclaw-guardrails/README.md
+++ b/aidbox-integrations/healthclaw-guardrails/README.md
@@ -1,0 +1,295 @@
+---
+features: [AI agents, MCP, PHI redaction, Audit trail, Step-up authorization, Human-in-the-loop, Multi-tenancy]
+languages: [Python, TypeScript, Shell]
+runtimes: [Docker]
+---
+# HealthClaw Guardrails in front of Aidbox
+
+Aidbox holds the record. An AI agent talks to a guardrail proxy in front of
+it, and the proxy enforces four things the FHIR authorization model does not
+express: redact on read, audit every access, step up on writes, and hold
+anything irreversible for a human.
+
+```text
+AI agent ──▶ MCP server ──▶ Guardrail proxy ──▶ Aidbox
+  :3001                        :5000              :8080
+                                 │
+                          PHI redaction
+                          Audit trail
+                          Step-up auth
+                          Human-in-the-loop
+                          Tenant isolation
+```
+
+Nothing about the Aidbox side is unusual, and that is the point. The guardrail
+layer is additive; the FHIR server underneath keeps behaving like a FHIR
+server, and still holds the complete, fully-identified record.
+
+Companion to the article *"We standardized how to get health data. We never
+standardized what an agent may do with it."*
+
+## Prerequisites
+
+1. Docker
+2. Cloned repository
+
+```bash
+git clone https://github.com/Aidbox/examples.git
+cd examples/aidbox-integrations/healthclaw-guardrails
+```
+
+## Run it
+
+```bash
+cp .env.example .env      # set STEP_UP_SECRET and MCP_AUTH_TOKEN;
+                          # BOX_LICENSE stays commented out
+docker compose up -d
+```
+
+**Activate Aidbox.** Open <http://localhost:8080> and click *Continue with
+Aidbox account*. Until you do, Aidbox answers **every** route with a 302 to
+"Log in to activate Aidbox" — including `/health`, so the symptom reads as a
+network fault rather than a licence one. Compose is waiting on that health
+check and starts the proxy by itself once you are through. To skip the click
+entirely, put a free self-hosted key from [aidbox.app](https://aidbox.app)
+(account → licenses) and uncomment `BOX_LICENSE` in `.env`; unattended runs
+need that path. Do not uncomment it and leave it blank — Aidbox rejects an
+empty licence harder than a missing one, and refuses to boot.
+
+```bash
+./scripts/seed-aidbox.sh  # 1 Patient, 1 Condition, 3 Observations
+./scripts/walkthrough.sh  # the steps below, asserted
+```
+
+`walkthrough.sh` opens with a preflight that separates "Aidbox is not
+activated" from "the proxy image is too old to authenticate", because both
+otherwise surface as the same unexplained failure several steps later.
+
+There is a second harness in [`qa/`](qa/) that asserts the same properties
+from a browser and records the run as a video:
+
+```bash
+cd qa && npm install && npx playwright install chromium
+HEALTHCLAW_PORT=5099 npx playwright test      # artifacts/**/video.webm
+```
+
+It exists because a recording made separately from the assertions is a
+re-enactment, and re-enactments drift from the system they depict. Here the
+assertions and the frames come from the same requests, so a video showing a
+pass cannot exist unless the pass happened.
+
+Two more things that will bite you:
+
+- **macOS holds port 5000.** AirPlay Receiver (ControlCenter) listens there,
+  so `up` fails with "address already in use". Set `HEALTHCLAW_PORT=5099` in
+  `.env` and read `:5099` for `:5000` throughout.
+- **The image tags are pinned, deliberately.** `:latest` is only republished
+  when a release is cut, and for a while it pointed at a build that predated
+  upstream authentication — so it ignored the two `FHIR_UPSTREAM_CLIENT_*`
+  variables this example depends on, and the wiring below was configured
+  correctly and did nothing. A pin turns that into a pull failure instead.
+
+## What each step shows
+
+### 1. The same read, with and without governance
+
+Direct to Aidbox, the record is fully identified, as it should be:
+
+```bash
+curl -u "$AIDBOX_CLIENT:$AIDBOX_SECRET" http://localhost:8080/fhir/Patient/pt-demo
+```
+
+```json
+{ "resourceType": "Patient", "id": "pt-demo",
+  "name": [{"given": ["Maria"], "family": "Alvarez"}],
+  "identifier": [{"system": "urn:mrn", "value": "MRN-88214"}],
+  "birthDate": "1974-03-11",
+  "address": [{"line": ["221 Baker St"], "city": "Pittsburgh"}] }
+```
+
+Through the proxy, same resource, same Aidbox. Reads are authenticated too —
+`READ_AUTH_ENABLED` is on, so a tenant header alone gets a 401, and the same
+step-up token that authorises a write is what proves the tenant claim on a
+read:
+
+```bash
+TOKEN=$(curl -s -X POST -H 'Content-Type: application/json' \
+  -H "X-Tenant-Id: demo" -d '{"tenant_id":"demo"}' \
+  http://localhost:5000/r6/fhir/internal/step-up-token | jq -r .token)
+
+curl -H "X-Tenant-Id: demo" -H "X-Step-Up-Token: $TOKEN" \
+  http://localhost:5000/r6/fhir/Patient/pt-demo
+```
+
+```json
+{ "resourceType": "Patient", "id": "pt-demo",
+  "name": [{"given": ["M."], "family": "A."}],
+  "identifier": [{"system": "urn:mrn", "value": "***8214"}],
+  "birthDate": "1974",
+  "address": [{"state": "PA"}] }
+```
+
+The name is reduced to initials, the MRN is masked, the address and phone are
+gone, and the birth date is truncated to a year.
+
+Forget the token and you get an OperationOutcome — which is worth knowing
+because an OperationOutcome contains no PHI, so a redaction check written as
+"none of the identifiers appear in the response" passes on a refusal without
+testing redaction at all. `walkthrough.sh` shipped with exactly that hole; it
+now asserts it received `Patient/pt-demo` before it asserts anything about
+what the Patient contains.
+
+Aidbox still holds the complete record. Redaction is a property of the path
+the agent uses, not a modification of the data. `walkthrough.sh` asserts this
+by looking for the distinctive values themselves rather than for a mask
+string, because a redactor that returned `***masked***` and nothing else
+would satisfy the lazier check.
+
+### 2. The read left a record
+
+```bash
+curl -H "X-Tenant-Id: demo" -H "X-Step-Up-Token: $TOKEN" \
+  "http://localhost:5000/r6/fhir/AuditEvent?_count=5"
+```
+
+An AuditEvent naming the tenant, the agent, the resource and the time, with no
+PHI in the detail — so the record you hand a reviewer is safe to hand over.
+
+### 3. A write, and two gates that do not substitute for each other
+
+Recording a blood pressure needs a machine credential *and* a human
+confirmation, and neither one stands in for the other. Four requests show
+that better than two, because a pair of refusals in sequence only proves that
+*some* refusal happened:
+
+| `X-Human-Confirmed` | `X-Step-Up-Token` | result |
+|---|---|---|
+| — | — | **428** confirmation missing |
+| `true` | — | **401** a confirmation is not a credential |
+| — | valid | **428** a credential is not a confirmation |
+| `true` | valid | **201** |
+
+The bare request reports **428** rather than 401 because the human-in-the-loop
+check runs in a `before_request` hook, ahead of every handler's auth gate —
+that ordering is what stops an unauthenticated caller reaching the handler at
+all. Worth knowing before you read a status code as evidence of which gate
+you tripped.
+
+Only after both does the Observation reach Aidbox, which the walkthrough
+verifies by asking Aidbox rather than the proxy — a proxy reporting its own
+201 says nothing about what was stored:
+
+```bash
+curl -u "$AIDBOX_CLIENT:$AIDBOX_SECRET" \
+  "http://localhost:8080/fhir/Observation?subject=Patient/pt-demo&code=85354-9"
+```
+
+That matrix is the whole argument. The agent did useful work. It could not
+finish alone.
+
+One caveat the table cannot carry: `X-Human-Confirmed` is set by the caller,
+so it evidences a human the way a checkbox does. It is a compensating
+control, not proof. See *What this example does not show* below.
+
+### 4. Grade the deployment
+
+```bash
+curl "http://localhost:5000/r6/fhir/\$conformance?format=text"
+```
+
+Seven properties, run against the deployment that is actually running. The
+same harness runs in HealthClaw's CI as a merge gate, so a regression shows
+up as a grade change rather than an incident.
+
+**Against Aidbox this scores B (6/7), not A.** The example says so rather
+than quietly asserting a softer threshold, because the failure is worth
+knowing: in upstream mode a search carrying an unknown parameter is forwarded
+to Aidbox, which answers 404 or 502, instead of being refused by the
+guardrail with an OperationOutcome naming the parameter. Error fidelity is
+graded on what the caller is told when something goes wrong, and in proxy
+mode part of that answer is currently Aidbox's, not ours. Tracked as
+[HealthClawGuardrails#498](https://github.com/aks129/HealthClawGuardrails/issues/498).
+
+The other six hold. `walkthrough.sh` asserts exactly that — every property
+except error fidelity must pass, so any other regression goes red, and the
+day the gap closes the same assertion passes at 7/7 unchanged.
+
+Two of those six only started holding here recently. The harness builds a
+clinical Observation referencing `Patient/conformance-subject`, a patient
+nothing creates. The local SQLite store accepts it because it validates no
+references; Aidbox refuses it, every clinical-write probe returned 422, and
+the report concluded *"the gate blocks confirmed writes too, so its 428s
+prove nothing"* — a true measurement with the wrong cause attached. The gate
+was fine. The probes now create a subject first.
+
+### 5. What the agent actually connects to
+
+```bash
+curl -X POST http://localhost:3001/mcp/rpc -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+# 401
+
+curl -X POST http://localhost:3001/mcp/rpc -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $MCP_AUTH_TOKEN" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+# 27 tools
+```
+
+The MCP server refuses to start at all without `MCP_AUTH_TOKEN` rather than
+serving an unauthenticated tool endpoint. `MCP_PUBLIC_DEMO=true` is the
+documented alternative and is deliberately not used here: an example about
+what an agent may do with health data should not open with an
+unauthenticated tool server.
+
+This step exists because for a long time the service never ran. The proxy's
+health check called `curl`, which is not in that image, so it exited 127 on
+every probe and reported unhealthy forever — and `mcp`, which waits on
+`condition: service_healthy`, never started. The diagram at the top of this
+file opens with the MCP server, and nothing had ever asked whether it was
+there. Both checks now run in `walkthrough.sh`.
+
+## How the two servers are wired
+
+The proxy holds its own Aidbox credential — the `healthclaw` Client in
+[`init-bundle/bundle.json`](init-bundle/bundle.json) — so the agent never
+receives, and never needs, an Aidbox credential:
+
+```yaml
+healthclaw:
+  environment:
+    FHIR_UPSTREAM_URL: http://aidbox:8080/fhir
+    FHIR_UPSTREAM_CLIENT_ID: healthclaw
+    FHIR_UPSTREAM_CLIENT_SECRET: ${FHIR_UPSTREAM_CLIENT_SECRET}
+    STEP_UP_SECRET: ${STEP_UP_SECRET}
+    READ_AUTH_ENABLED: "true"
+```
+
+The AccessPolicy scopes that Client to `/fhir/*`. An agent that gets past the
+proxy still has no route to Aidbox's admin surface, `$sql`, or the Client that
+authorizes it.
+
+`FHIR_LOCAL_BASE_URL` makes the proxy rewrite Aidbox's base URL out of every
+response. An agent that learns the real endpoint will try to route around the
+guardrails, so it is never told what it is.
+
+## What this example does not show
+
+- **A licence check is not a guardrail.** Everything above assumes Aidbox is
+  reachable. The proxy's failure mode when it is not is a degraded health
+  check and a 502, not a silent empty bundle — but that is a different
+  property from the four this example demonstrates.
+- **Redaction is a compensating control, not a de-identification
+  determination.** A record with a rare diagnosis and an unusual date
+  sequence is not made unlinkable by masking a name. What changes is the
+  default.
+- **The clinical-write human gate is a header today** (`X-Human-Confirmed`),
+  which the caller that sets it can spoof. It is documented as a compensating
+  control rather than proof a human acted; the action rail's separate
+  approval endpoint is the real mechanism. HealthClaw tracks this as a known
+  gap.
+
+## Links
+
+- HealthClaw Guardrails: <https://github.com/aks129/HealthClawGuardrails> (MIT)
+- Live conformance grade: <https://app.healthclaw.io/r6/fhir/$conformance>
+- Aidbox: <https://aidbox.app>

--- a/aidbox-integrations/healthclaw-guardrails/docker-compose.yaml
+++ b/aidbox-integrations/healthclaw-guardrails/docker-compose.yaml
@@ -1,0 +1,169 @@
+volumes:
+  postgres_data: {}
+
+services:
+  postgres:
+    image: postgres:18
+    volumes:
+      - postgres_data:/var/lib/postgresql:delegated
+    command:
+      - postgres
+      - -c
+      - shared_preload_libraries=pg_stat_statements
+    environment:
+      POSTGRES_USER: aidbox
+      POSTGRES_PORT: "5432"
+      POSTGRES_DB: aidbox
+      POSTGRES_PASSWORD: hb1NnSed7w
+
+  # The system of record. Holds the COMPLETE, fully-identified resource.
+  # Nothing below ever modifies it: redaction is a property of the path the
+  # agent takes, not an edit to the data.
+  aidbox:
+    image: healthsamurai/aidboxone:edge
+    pull_policy: always
+    depends_on:
+      - postgres
+    ports:
+      - 8080:8080
+    volumes:
+      - ./init-bundle:/app/init-bundle:ro
+    # LIST form, not the mapping form used elsewhere in this file, for the
+    # sake of the first entry. Aidbox needs activating, and until it is, it
+    # answers EVERY route with a 302 to a browser page reading "Log in to
+    # activate Aidbox" — including /health, so the symptom looks like a
+    # network fault rather than a licence one. Two ways to clear it:
+    #
+    #   set nothing     open http://localhost:8080 and click "Continue with
+    #                   Aidbox account". This is what Aidbox's own examples
+    #                   assume, and it needs no .env edit.
+    #   set BOX_LICENSE a self-hosted key from aidbox.app (account ->
+    #                   licenses). Unattended runs and CI want this one.
+    #
+    # A bare `- BOX_LICENSE` is the only form that expresses that choice.
+    # `BOX_LICENSE: ${BOX_LICENSE:-}` looks equivalent and is not: it sets
+    # the variable to the empty string, and Aidbox rejects an empty licence
+    # harder than a missing one — it refuses to boot at all with "License is
+    # invalid ... not in correct format". Unset and empty are different
+    # states here, and empty is the one that breaks. So: absent from .env
+    # means absent from the container.
+    environment:
+      - BOX_LICENSE
+      - BOX_ADMIN_PASSWORD=uN6jhgu8eo
+      - BOX_BOOTSTRAP_FHIR_PACKAGES=hl7.fhir.r4.core#4.0.1
+      - BOX_DB_DATABASE=aidbox
+      - BOX_DB_HOST=postgres
+      - BOX_DB_PASSWORD=hb1NnSed7w
+      - BOX_DB_PORT=5432
+      - BOX_DB_USER=aidbox
+      - BOX_FHIR_COMPLIANT_MODE=true
+      - BOX_FHIR_CORRECT_AIDBOX_FORMAT=true
+      - BOX_FHIR_SCHEMA_VALIDATION=true
+      - BOX_ROOT_CLIENT_SECRET=qNbQS6sw82
+      - BOX_SECURITY_AUDIT_LOG_ENABLED=true
+      - BOX_SECURITY_DEV_MODE=true
+      - BOX_SETTINGS_MODE=read-write
+      - BOX_WEB_BASE_URL=http://localhost:8080
+      - BOX_WEB_PORT=8080
+      - BOX_INIT_BUNDLE=file:///app/init-bundle/bundle.json
+    healthcheck:
+      # Explicitly 200, NOT `curl -f`. Until Aidbox is activated it answers
+      # /health with a 302 to the activation page, and `curl -f` only fails
+      # on 4xx/5xx — so the obvious `curl -f http://localhost:8080/health`
+      # reports an unactivated Aidbox as healthy, compose starts the proxy
+      # against a server that serves nothing, and the first real symptom
+      # arrives several steps later somewhere else entirely.
+      #
+      # Checking for 200 makes this the activation gate it was supposed to
+      # be: with BOX_LICENSE unset, compose waits here until you click
+      # through in the browser, then starts the proxy on its own. The window
+      # is generous for that reason — a 7-minute one turns a coffee refill
+      # into a failed `up`.
+      test: ["CMD-SHELL",
+             "curl -sS -o /dev/null -w '%{http_code}' http://localhost:8080/health | grep -q '^200$$'"]
+      interval: 5s
+      timeout: 5s
+      retries: 180
+      start_period: 30s
+
+  # The guardrail layer. Every agent-facing read and write goes through here.
+  healthclaw:
+    # PINNED, not :latest. `latest` is only republished when a release is cut,
+    # so for a while it pointed at 1.9.0 — an image that predates upstream
+    # authentication and therefore ignored the two FHIR_UPSTREAM_CLIENT_*
+    # variables set below. The example read as correct and could not work.
+    # A pin makes that class of drift a pull failure instead of a silent one.
+    image: ghcr.io/aks129/healthclaw-guardrails:1.10.0
+    depends_on:
+      aidbox:
+        condition: service_healthy
+    ports:
+      # On macOS, port 5000 is held by AirPlay Receiver (ControlCenter) unless
+      # you turn it off, so `up` fails with "address already in use". Set
+      # HEALTHCLAW_PORT=5099 in .env and use that port in the curls below.
+      - ${HEALTHCLAW_PORT:-5000}:5000
+    # init-db first. Without it the first request fails as an AuditWriteError
+    # wrapping an OperationalError — a missing schema that reads like an audit
+    # bug and has cost more than one person an afternoon.
+    command: >
+      sh -c "flask --app main init-db &&
+             gunicorn main:app --bind 0.0.0.0:5000 --workers 2 --timeout 300"
+    environment:
+      PORT: "5000"
+
+      # Point the guardrails at Aidbox. The proxy holds its OWN credential —
+      # the `healthclaw` Client created by init-bundle/bundle.json — so the
+      # agent never receives, and never needs, an Aidbox credential.
+      FHIR_UPSTREAM_URL: http://aidbox:8080/fhir
+      FHIR_UPSTREAM_CLIENT_ID: healthclaw
+      FHIR_UPSTREAM_CLIENT_SECRET: ${FHIR_UPSTREAM_CLIENT_SECRET:-healthclaw-secret}
+
+      # Responses are rewritten so this base URL, and never Aidbox's, is what
+      # the agent sees. An agent that learns the real endpoint will try to
+      # route around the proxy.
+      FHIR_LOCAL_BASE_URL: http://localhost:5000/r6/fhir
+
+      STEP_UP_SECRET: ${STEP_UP_SECRET:?set STEP_UP_SECRET in .env}
+      READ_AUTH_ENABLED: "true"
+      APP_ENV: development
+      DATABASE_URL: sqlite:////tmp/healthclaw.db
+    healthcheck:
+      # python, NOT curl — the guardrails image does not ship curl, so
+      # `curl -f ...` exited 127 ("not found") on every probe. The proxy was
+      # healthy the whole time and reported unhealthy forever, which meant
+      # the mcp service below — `condition: service_healthy` — never started
+      # at all. The example's own diagram opens with the MCP server, and it
+      # had never once come up.
+      #
+      # urlopen raises on any non-2xx, so a degraded 503 fails the probe the
+      # same way a refused connection does.
+      test: ["CMD-SHELL",
+             "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:5000/r6/fhir/health', timeout=4)\""]
+      interval: 5s
+      timeout: 5s
+      retries: 40
+      start_period: 15s
+
+  # What the agent actually connects to.
+  mcp:
+    image: ghcr.io/aks129/healthclaw-mcp-server:1.10.0
+    depends_on:
+      healthclaw:
+        condition: service_healthy
+    ports:
+      - 3001:3001
+    environment:
+      PORT: "3001"
+      FHIR_BASE_URL: http://healthclaw:5000/r6/fhir
+      TENANT_ID: demo
+
+      # REQUIRED, and the server refuses to start without it — it fail-closes
+      # rather than serving an unauthenticated MCP endpoint, which is the
+      # behaviour you want and also the reason this service crash-looped
+      # unnoticed for as long as the proxy's health check was broken: nothing
+      # depending on it ever got far enough to start it.
+      #
+      # MCP_PUBLIC_DEMO=true is the documented alternative and is deliberately
+      # not used here. An example about what an agent may do with health data
+      # should not open with an unauthenticated tool server.
+      MCP_AUTH_TOKEN: ${MCP_AUTH_TOKEN:?set MCP_AUTH_TOKEN in .env}

--- a/aidbox-integrations/healthclaw-guardrails/init-bundle/bundle.json
+++ b/aidbox-integrations/healthclaw-guardrails/init-bundle/bundle.json
@@ -1,0 +1,31 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "request": { "method": "PUT", "url": "Client/healthclaw" },
+      "resource": {
+        "resourceType": "Client",
+        "id": "healthclaw",
+        "secret": "healthclaw-secret",
+        "grant_types": ["basic"]
+      }
+    },
+    {
+      "request": { "method": "PUT", "url": "AccessPolicy/healthclaw-fhir-only" },
+      "resource": {
+        "resourceType": "AccessPolicy",
+        "id": "healthclaw-fhir-only",
+        "description": "The guardrail proxy reads and writes FHIR, and nothing else. It has no route to Aidbox's own admin surface, so an agent that gets past the proxy still cannot reach $sql, the console, or the Client that authorises it.",
+        "engine": "matcho",
+        "matcho": {
+          "uri": "#/fhir/.*",
+          "client": { "id": "healthclaw" }
+        },
+        "link": [
+          { "id": "healthclaw", "resourceType": "Client" }
+        ]
+      }
+    }
+  ]
+}

--- a/aidbox-integrations/healthclaw-guardrails/qa/.gitignore
+++ b/aidbox-integrations/healthclaw-guardrails/qa/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+node_modules/
+artifacts/

--- a/aidbox-integrations/healthclaw-guardrails/qa/demo.spec.ts
+++ b/aidbox-integrations/healthclaw-guardrails/qa/demo.spec.ts
@@ -1,0 +1,331 @@
+import { test, expect, APIRequestContext } from '@playwright/test';
+
+/**
+ * The example, asserted against the running stack — and filmed while it runs.
+ *
+ * Every number on screen is a live response. Nothing here is a re-enactment:
+ * the assertions and the recording come from the same requests, so a video
+ * that shows a pass cannot exist unless the pass happened. That property is
+ * the reason this is a test rather than a screen capture with narration.
+ *
+ * Requires the stack to be up and seeded:
+ *   docker compose up -d && ./scripts/seed-aidbox.sh
+ */
+
+const PROXY = `http://localhost:${process.env.HEALTHCLAW_PORT || '5000'}`;
+const AIDBOX = process.env.AIDBOX_URL || 'http://localhost:8080';
+const AIDBOX_AUTH = 'Basic ' + Buffer.from(
+  `${process.env.AIDBOX_CLIENT || 'root'}:${process.env.AIDBOX_SECRET || 'qNbQS6sw82'}`
+).toString('base64');
+const TENANT = process.env.TENANT || 'demo';
+const MCP = `http://localhost:${process.env.MCP_PORT || '3001'}`;
+const MCP_TOKEN = process.env.MCP_AUTH_TOKEN || '';
+
+/** Values that must never appear on the agent's side of the proxy. */
+const IDENTIFIERS = ['Alvarez', 'Maria', 'MRN-88214', '221 Baker St',
+                     '555-867-5309', '1974-03-11'];
+
+const OBSERVATION = {
+  resourceType: 'Observation',
+  status: 'final',
+  subject: { reference: 'Patient/pt-demo' },
+  effectiveDateTime: '2026-08-11',
+  code: { coding: [{ system: 'http://loinc.org', code: '85354-9' }] },
+  valueQuantity: { value: 128, unit: 'mmHg' },
+};
+
+const SHELL = `
+<style>
+  :root{
+    --ground:#0f1620; --panel:#16202c; --edge:#243244;
+    --ink:#e3eaf2; --muted:#8598ad;
+    --guard:#e0a33e;      /* the guardrail acting: held, refused, masked */
+    --pass:#57c795;       /* an assertion that held */
+    --raw:#7fb2e5;        /* the record as the system of record holds it */
+  }
+  *{box-sizing:border-box}
+  body{
+    margin:0; background:var(--ground); color:var(--ink);
+    font:15px/1.5 ui-sans-serif,-apple-system,"Segoe UI",sans-serif;
+    padding:22px 30px;
+  }
+  header{display:flex; align-items:baseline; gap:14px; margin-bottom:6px}
+  h1{font-size:19px; font-weight:600; margin:0; letter-spacing:-0.01em}
+  .sub{color:var(--muted); font-size:13px}
+  .flow{
+    color:var(--muted); font:12px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace;
+    margin:2px 0 16px; letter-spacing:0.02em;
+  }
+  .step{
+    background:var(--panel); border:1px solid var(--edge); border-radius:9px;
+    padding:13px 16px; margin-bottom:11px;
+    opacity:0; transform:translateY(6px);
+    animation:in .28s ease-out forwards;
+  }
+  @keyframes in{to{opacity:1; transform:none}}
+  .head{display:flex; align-items:center; gap:10px; margin-bottom:9px}
+  .n{
+    color:var(--muted); font:11px ui-monospace,monospace; letter-spacing:.1em;
+    text-transform:uppercase;
+  }
+  .t{font-weight:600; font-size:14px}
+  .chip{
+    margin-left:auto; font:11px/1 ui-monospace,monospace; padding:5px 9px;
+    border-radius:20px; letter-spacing:.04em;
+  }
+  .chip.pass{background:rgba(87,199,149,.14); color:var(--pass);
+             border:1px solid rgba(87,199,149,.32)}
+  .cols{display:grid; grid-template-columns:1fr 1fr; gap:11px}
+  .cols.three{grid-template-columns:1fr 1fr 1fr}
+  .box{border:1px solid var(--edge); border-radius:7px; padding:9px 11px;
+       background:rgba(0,0,0,.18)}
+  .lbl{font:10px ui-monospace,monospace; letter-spacing:.09em;
+       text-transform:uppercase; color:var(--muted); margin-bottom:6px}
+  .box.raw .lbl{color:var(--raw)}
+  .box.guard .lbl{color:var(--guard)}
+  pre{margin:0; font:12px/1.55 ui-monospace,SFMono-Regular,Menlo,monospace;
+      white-space:pre-wrap; word-break:break-word}
+  .raw pre{color:var(--raw)}
+  .guard pre{color:var(--guard)}
+  table{width:100%; border-collapse:collapse; font:12px ui-monospace,monospace}
+  td,th{padding:5px 8px; text-align:left; border-bottom:1px solid var(--edge)}
+  th{color:var(--muted); font-weight:400; font-size:10px; letter-spacing:.08em;
+     text-transform:uppercase}
+  tr:last-child td{border-bottom:none}
+  .code{color:var(--guard); font-weight:600}
+  .code.ok{color:var(--pass)}
+  .note{color:var(--muted); font-size:12px; margin-top:8px; line-height:1.5}
+  .yes{color:var(--pass)} .no{color:var(--muted)}
+</style>
+<header>
+  <h1>HealthClaw Guardrails in front of Aidbox</h1>
+  <span class="sub">live stack &middot; every value below is a real response</span>
+</header>
+<div class="flow">AI agent &rarr; MCP server &rarr; guardrail proxy &rarr; Aidbox &nbsp;|&nbsp; redact &middot; audit &middot; step-up &middot; human-in-the-loop</div>
+<main id="out"></main>
+`;
+
+/** Append one finished step to the page. */
+async function render(page, html: string) {
+  await page.evaluate((h) => {
+    const d = document.createElement('div');
+    d.className = 'step';
+    d.innerHTML = h;
+    document.getElementById('out')!.appendChild(d);
+    d.scrollIntoView({ block: 'end' });
+  }, html);
+  // Pacing is for the recording, not the assertions. A step that
+  // appears and scrolls away in under a second is a test that also
+  // happens to produce an unwatchable file.
+  await page.waitForTimeout(1500);
+}
+
+const head = (n: string, t: string) =>
+  `<div class="head"><span class="n">${n}</span><span class="t">${t}</span>` +
+  `<span class="chip pass">PASS</span></div>`;
+
+const esc = (s: string) =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+async function stepUpToken(request: APIRequestContext): Promise<string> {
+  const r = await request.post(`${PROXY}/r6/fhir/internal/step-up-token`, {
+    headers: { 'X-Tenant-Id': TENANT, 'Content-Type': 'application/json' },
+    data: { tenant_id: TENANT },
+  });
+  expect(r.status(), 'minting a step-up token').toBe(200);
+  const token = (await r.json()).token;
+  expect(token, 'the mint returned a token').toBeTruthy();
+  return token;
+}
+
+test('the guardrails hold, in front of a real FHIR server', async ({ page, request }) => {
+  await page.setContent(SHELL);
+  await page.waitForTimeout(1200);
+
+  // ---- 0. The stack is what we think it is -------------------------------
+  // Asserted first because every step below is meaningless if the proxy is
+  // serving its own SQLite store instead of Aidbox — and it would still pass
+  // most of them.
+  const health = await (await request.get(`${PROXY}/r6/fhir/health`)).json();
+  expect(health.mode, 'proxy must be in upstream mode, not local').toBe('upstream');
+  expect(health.checks.upstream.status, 'proxy must reach Aidbox').toBe('connected');
+
+  const anon = await request.get(`${AIDBOX}/fhir/Patient/pt-demo`);
+  expect(anon.status(), 'Aidbox must refuse anonymous callers').not.toBe(200);
+
+  await render(page, head('00', 'The proxy is talking to Aidbox, with its own credential') + `
+    <div class="cols">
+      <div class="box"><div class="lbl">proxy /health</div><pre>mode      ${health.mode}
+upstream  ${health.checks.upstream.status}
+version   ${health.version}</pre></div>
+      <div class="box"><div class="lbl">Aidbox, no credential</div><pre>GET /fhir/Patient/pt-demo
+&rarr; HTTP ${anon.status()}</pre></div>
+    </div>
+    <div class="note">The agent never holds an Aidbox credential. The proxy does, and
+    Aidbox refuses callers who do not &mdash; so &ldquo;the proxy authenticates&rdquo; is a
+    fact here, not a diagram.</div>`);
+
+  // ---- 1. The same record, both ways -------------------------------------
+  const token = await stepUpToken(request);
+  const authed = { 'X-Tenant-Id': TENANT, 'X-Step-Up-Token': token };
+
+  const direct = await (await request.get(`${AIDBOX}/fhir/Patient/pt-demo`,
+    { headers: { Authorization: AIDBOX_AUTH } })).json();
+  const noToken = await request.get(`${PROXY}/r6/fhir/Patient/pt-demo`,
+    { headers: { 'X-Tenant-Id': TENANT } });
+  const proxiedRes = await request.get(`${PROXY}/r6/fhir/Patient/pt-demo`,
+    { headers: authed });
+  const proxied = await proxiedRes.json();
+
+  // Reads are authenticated: a tenant header alone is not a credential.
+  expect(noToken.status(), 'a read without a token must be refused').toBe(401);
+
+  // The shape check comes FIRST and is the load-bearing one. A refusal
+  // contains none of the identifiers either, so "nothing leaked" is true of
+  // an error body — which is exactly how this demo passed while testing
+  // nothing at all.
+  expect(proxied.resourceType, 'the proxy must return the record itself').toBe('Patient');
+  expect(proxied.id).toBe('pt-demo');
+  expect(JSON.stringify(direct), 'Aidbox holds the identified record').toContain('Alvarez');
+  for (const id of IDENTIFIERS) {
+    expect(JSON.stringify(proxied), `identifier survived redaction: ${id}`).not.toContain(id);
+  }
+
+  const pick = (o: any) => JSON.stringify(
+    { name: o.name, identifier: o.identifier, birthDate: o.birthDate, address: o.address },
+    null, 1).replace(/\n\s*/g, ' ').replace(/([,{])\s/g, '$1\n  ');
+
+  await render(page, head('01', 'The same record, with and without governance') + `
+    <div class="cols three">
+      <div class="box raw"><div class="lbl">Aidbox &middot; system of record</div><pre>${esc(pick(direct))}</pre></div>
+      <div class="box"><div class="lbl">proxy &middot; tenant header only</div><pre>HTTP ${noToken.status()}
+a tenant claim is not
+a credential</pre></div>
+      <div class="box guard"><div class="lbl">proxy &middot; authenticated agent</div><pre>${esc(pick(proxied))}</pre></div>
+    </div>
+    <div class="note">Initials, a masked MRN, the year only, and the street gone &mdash; while
+    Aidbox still holds every character. Redaction is a property of the path the agent
+    takes, not an edit to the data.</div>`);
+
+  // ---- 2. The read left a record -----------------------------------------
+  const audit = await (await request.get(
+    `${PROXY}/r6/fhir/AuditEvent?_count=5`, { headers: authed })).json();
+  expect(audit.resourceType, 'expected a Bundle of AuditEvents').toBe('Bundle');
+  expect(audit.entry?.length, 'the read emitted no AuditEvent').toBeGreaterThan(0);
+  for (const id of IDENTIFIERS) {
+    expect(JSON.stringify(audit), `PHI in the audit trail: ${id}`).not.toContain(id);
+  }
+
+  const first = audit.entry[0].resource;
+  await render(page, head('02', 'The read left a record, and the record is safe to hand over') + `
+    <div class="cols">
+      <div class="box"><div class="lbl">AuditEvent &middot; ${audit.entry.length} of ${audit.total ?? audit.entry.length}</div><pre>action    ${first.action ?? '-'}
+recorded  ${(first.recorded ?? '').slice(0, 19)}
+type      ${first.type?.code ?? first.type?.coding?.[0]?.code ?? '-'}</pre></div>
+      <div class="box guard"><div class="lbl">checked for PHI</div><pre>${IDENTIFIERS.map(i => '&check; ' + i + ' absent').join('\n')}</pre></div>
+    </div>
+    <div class="note">Every access is written down, and the detail carries no PHI &mdash; so the
+    trail you hand a reviewer is safe to hand over.</div>`);
+
+  // ---- 3. Two gates, neither substituting for the other -------------------
+  const write = (headers: Record<string, string>) =>
+    request.post(`${PROXY}/r6/fhir/Observation`, {
+      headers: { 'X-Tenant-Id': TENANT, 'Content-Type': 'application/fhir+json', ...headers },
+      data: OBSERVATION,
+    });
+
+  const neither = await write({});
+  const humanOnly = await write({ 'X-Human-Confirmed': 'true' });
+  const tokenOnly = await write({ 'X-Step-Up-Token': token });
+  const both = await write({ 'X-Step-Up-Token': token, 'X-Human-Confirmed': 'true' });
+
+  expect(neither.status(), 'no gate satisfied').toBe(428);
+  expect(humanOnly.status(), 'a confirmation is not a credential').toBe(401);
+  expect(tokenOnly.status(), 'a credential is not a confirmation').toBe(428);
+  expect(both.status(), 'both gates satisfied must succeed').toBe(201);
+
+  // The proxy reporting its own 201 says nothing about storage. Ask Aidbox.
+  const landed = await (await request.get(
+    `${AIDBOX}/fhir/Observation?subject=Patient/pt-demo&code=85354-9`,
+    { headers: { Authorization: AIDBOX_AUTH } })).json();
+  expect(landed.total, 'the write returned 201 but Aidbox has no such Observation')
+    .toBeGreaterThan(0);
+
+  const row = (h: boolean, t: boolean, s: number, why: string) =>
+    `<tr><td>${h ? '<span class="yes">&check;</span>' : '<span class="no">&mdash;</span>'}</td>` +
+    `<td>${t ? '<span class="yes">&check;</span>' : '<span class="no">&mdash;</span>'}</td>` +
+    `<td class="code${s < 400 ? ' ok' : ''}">${s}</td><td style="color:var(--muted)">${why}</td></tr>`;
+
+  await render(page, head('03', 'A write, and two gates that do not substitute for each other') + `
+    <table>
+      <tr><th>human</th><th>step-up</th><th>status</th><th></th></tr>
+      ${row(false, false, neither.status(), 'human confirmation is missing')}
+      ${row(true, false, humanOnly.status(), 'a confirmation is not a credential')}
+      ${row(false, true, tokenOnly.status(), 'a credential is not a confirmation')}
+      ${row(true, true, both.status(), 'and only then')}
+    </table>
+    <div class="note">Confirmed in Aidbox, not taken from the proxy&rsquo;s own answer:
+    <strong>${landed.total}</strong> matching Observation(s) on Patient/pt-demo.
+    The agent did useful work. It could not finish alone.</div>`);
+
+  // ---- 4. Grade it -------------------------------------------------------
+  const conf = await (await request.get(`${PROXY}/r6/fhir/$conformance`)).json();
+  const failed = (conf.properties || []).filter((p: any) => !p.passed).map((p: any) => p.key);
+
+  // Not "the grade is A". Every property except the known proxy-mode gap
+  // must hold; the day HealthClawGuardrails#498 closes, this same assertion passes at 7/7.
+  expect(failed.filter((k: string) => k !== 'error_fidelity'),
+    'a property that should hold did not').toEqual([]);
+
+  const props = (conf.properties || []).map((p: any) =>
+    `<tr><td>${p.passed ? '<span class="yes">&check;</span>' : '<span style="color:var(--guard)">&mdash;</span>'}</td>` +
+    `<td>${p.key.replace(/_/g, ' ')}</td></tr>`).join('');
+
+  await render(page, head('04', 'Graded against the deployment that is actually running') + `
+    <div class="cols">
+      <div class="box"><div class="lbl">conformance</div><table>${props}</table></div>
+      <div class="box guard"><div class="lbl">grade ${conf.grade} &middot; ${conf.score.passed}/${conf.score.total}</div><pre>The one failure is error
+fidelity, and in upstream
+mode it measures how AIDBOX
+answers an unknown search
+parameter &mdash; not how the
+guardrail does.
+
+Stated, not graded away.
+Tracked as HealthClawGuardrails#498.</pre></div>
+    </div>
+    <div class="note">The same harness runs in CI as a merge gate, so a regression shows up
+    as a grade change rather than as an incident.</div>`);
+
+  // ---- 5. The tool surface the agent actually connects to ---------------
+  // The service this example's diagram opens with had never started: the
+  // proxy health check called curl, which is absent from that image, so mcp
+  // waited on a `service_healthy` that never arrived. Nothing asked.
+  const listBody = { jsonrpc: '2.0', id: 1, method: 'tools/list' };
+  const mcpAnon = await request.post(`${MCP}/mcp/rpc`, { data: listBody });
+  expect(mcpAnon.status(), 'the MCP server must refuse unauthenticated callers').toBe(401);
+
+  const mcpAuthed = await request.post(`${MCP}/mcp/rpc`, {
+    headers: { Authorization: `Bearer ${MCP_TOKEN}` }, data: listBody,
+  });
+  expect(mcpAuthed.status()).toBe(200);
+  const tools = (await mcpAuthed.json()).result?.tools ?? [];
+  expect(tools.length, 'the authenticated tool surface must be served').toBeGreaterThan(0);
+
+  await render(page, head('05', 'What the agent actually connects to') + `
+    <div class="cols">
+      <div class="box"><div class="lbl">tools/list &middot; no credential</div><pre>HTTP ${mcpAnon.status()}
+
+the MCP server refuses to
+start without a token at all,
+rather than serve an
+unauthenticated tool surface</pre></div>
+      <div class="box guard"><div class="lbl">tools/list &middot; authenticated &middot; ${tools.length} tools</div><pre>${tools.slice(0, 7).map((t: any) => '&middot; ' + t.name).join('\n')}
+&hellip; and ${tools.length - 7} more</pre></div>
+    </div>
+    <div class="note">Every one of those tools reaches Aidbox only through the guardrail
+    proxy above &mdash; so the four properties hold for the agent's whole surface, not
+    just for the requests in this demo.</div>`);
+
+  await page.waitForTimeout(3000);
+});

--- a/aidbox-integrations/healthclaw-guardrails/qa/package.json
+++ b/aidbox-integrations/healthclaw-guardrails/qa/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "aidbox-healthclaw-guardrails-qa",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Asserts the Aidbox example against the running stack, and records the run",
+  "scripts": {
+    "test": "playwright test",
+    "install:browsers": "playwright install --with-deps chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.62.1"
+  }
+}

--- a/aidbox-integrations/healthclaw-guardrails/qa/playwright.config.ts
+++ b/aidbox-integrations/healthclaw-guardrails/qa/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from '@playwright/test';
+
+// QA for the Aidbox example, and the recording of it — the same run.
+//
+// No `webServer`: this suite tests a stack that is ALREADY up
+// (`docker compose up -d` + `./scripts/seed-aidbox.sh`), because what is
+// under test is the composition, not the Flask app. A config that started
+// its own server would pass with Aidbox absent, which is the one outcome
+// this suite exists to rule out. It fails fast with a named reason instead.
+//
+// Video is on for every test rather than on failure: the artifact IS the
+// deliverable here, and a recording that only exists when something breaks
+// is not one you can send anybody.
+export default defineConfig({
+  testDir: '.',
+  fullyParallel: false,
+  workers: 1,
+  timeout: 120_000,
+  reporter: [['list']],
+  use: {
+    // 720p, and the page is laid out for it. Anything narrower turns the
+    // side-by-side comparison — the whole point of step 1 — into a stack.
+    viewport: { width: 1280, height: 720 },
+    video: { mode: 'on', size: { width: 1280, height: 720 } },
+    trace: 'retain-on-failure',
+  },
+  outputDir: './artifacts',
+});

--- a/aidbox-integrations/healthclaw-guardrails/scripts/seed-aidbox.sh
+++ b/aidbox-integrations/healthclaw-guardrails/scripts/seed-aidbox.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Seed Aidbox with one synthetic patient: one Patient, three Observations,
+# one Condition. Written straight to Aidbox, NOT through the guardrail proxy,
+# because the point of the walkthrough is to compare the two paths over the
+# same stored bytes.
+#
+# Everything here is synthetic. Maria Alvarez does not exist.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+[ -f .env ] && set -a && . ./.env && set +a
+
+AIDBOX_URL="${AIDBOX_URL:-http://localhost:8080}"
+AIDBOX_CLIENT="${AIDBOX_CLIENT:-root}"
+AIDBOX_SECRET="${AIDBOX_SECRET:-qNbQS6sw82}"
+
+echo "Seeding ${AIDBOX_URL} ..."
+
+response=$(curl -sS -u "${AIDBOX_CLIENT}:${AIDBOX_SECRET}" \
+  -X POST "${AIDBOX_URL}/fhir" \
+  -H 'Content-Type: application/json' \
+  -d @- <<'JSON'
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "request": { "method": "PUT", "url": "/Patient/pt-demo" },
+      "resource": {
+        "resourceType": "Patient",
+        "id": "pt-demo",
+        "name": [{ "given": ["Maria"], "family": "Alvarez" }],
+        "identifier": [{ "system": "urn:mrn", "value": "MRN-88214" }],
+        "gender": "female",
+        "birthDate": "1974-03-11",
+        "telecom": [{ "system": "phone", "value": "555-867-5309" }],
+        "address": [{ "line": ["221 Baker St"], "city": "Pittsburgh", "state": "PA", "postalCode": "15213" }]
+      }
+    },
+    {
+      "request": { "method": "PUT", "url": "/Condition/cond-demo" },
+      "resource": {
+        "resourceType": "Condition",
+        "id": "cond-demo",
+        "subject": { "reference": "Patient/pt-demo" },
+        "clinicalStatus": {
+          "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/condition-clinical", "code": "active" }]
+        },
+        "code": {
+          "coding": [{ "system": "http://hl7.org/fhir/sid/icd-10-cm", "code": "E11.9", "display": "Type 2 diabetes mellitus without complications" }]
+        },
+        "onsetDateTime": "2019-06-01"
+      }
+    },
+    {
+      "request": { "method": "PUT", "url": "/Observation/obs-a1c" },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "obs-a1c",
+        "status": "final",
+        "subject": { "reference": "Patient/pt-demo" },
+        "effectiveDateTime": "2026-07-14",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "4548-4", "display": "Hemoglobin A1c/Hemoglobin.total in Blood" }] },
+        "valueQuantity": { "value": 8.1, "unit": "%", "system": "http://unitsofmeasure.org", "code": "%" }
+      }
+    },
+    {
+      "request": { "method": "PUT", "url": "/Observation/obs-glucose" },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "obs-glucose",
+        "status": "final",
+        "subject": { "reference": "Patient/pt-demo" },
+        "effectiveDateTime": "2026-07-14",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "2339-0", "display": "Glucose [Mass/volume] in Blood" }] },
+        "valueQuantity": { "value": 180, "unit": "mg/dL", "system": "http://unitsofmeasure.org", "code": "mg/dL" }
+      }
+    },
+    {
+      "request": { "method": "PUT", "url": "/Observation/obs-ldl" },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "obs-ldl",
+        "status": "final",
+        "subject": { "reference": "Patient/pt-demo" },
+        "effectiveDateTime": "2026-07-14",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "13457-7", "display": "Cholesterol in LDL [Mass/volume] in Serum or Plasma by calculation" }] },
+        "valueQuantity": { "value": 142, "unit": "mg/dL", "system": "http://unitsofmeasure.org", "code": "mg/dL" }
+      }
+    }
+  ]
+}
+JSON
+)
+
+# A transaction Bundle returns 200 even when an entry failed, so check the
+# entries rather than the status code. Reporting a seed that did not happen
+# as a success is the failure mode this whole example is about.
+python3 - "$response" <<'PY'
+import json, sys
+body = json.loads(sys.argv[1])
+entries = body.get("entry", [])
+if not entries:
+    print("SEED FAILED: no entries in the response", file=sys.stderr)
+    print(json.dumps(body, indent=2)[:2000], file=sys.stderr)
+    sys.exit(1)
+bad = [e for e in entries
+       if not str((e.get("response") or {}).get("status", "")).startswith(("200", "201"))]
+if bad:
+    print(f"SEED FAILED: {len(bad)} of {len(entries)} entries rejected", file=sys.stderr)
+    print(json.dumps(bad, indent=2)[:2000], file=sys.stderr)
+    sys.exit(1)
+print(f"Seeded {len(entries)} resources: 1 Patient, 1 Condition, 3 Observations.")
+PY

--- a/aidbox-integrations/healthclaw-guardrails/scripts/walkthrough.sh
+++ b/aidbox-integrations/healthclaw-guardrails/scripts/walkthrough.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# The five-step walkthrough from the article, as something you can run.
+#
+# Each step prints what it asked for and what came back. Steps that assert a
+# guardrail FAIL LOUDLY when the guardrail does not hold — a walkthrough that
+# prints "OK" whatever happens is a demo of itself, not of the system.
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+[ -f .env ] && set -a && . ./.env && set +a
+
+AIDBOX_URL="${AIDBOX_URL:-http://localhost:8080}"
+AIDBOX_CLIENT="${AIDBOX_CLIENT:-root}"
+AIDBOX_SECRET="${AIDBOX_SECRET:-qNbQS6sw82}"
+HC="http://localhost:${HEALTHCLAW_PORT:-5000}"
+TENANT="${TENANT:-demo}"
+
+fail=0
+step() { printf '\n\033[1m%s\033[0m\n' "$*"; }
+ok()   { printf '  \033[32mPASS\033[0m %s\n' "$*"; }
+bad()  { printf '  \033[31mFAIL\033[0m %s\n' "$*"; fail=1; }
+die()  { printf '\n\033[31m%s\033[0m\n' "$*"; exit 2; }
+
+# ---------------------------------------------------------------------------
+# Preflight. Two setup failures produce misleading symptoms further down, so
+# they are named here rather than left to surface as a puzzling 401 in step 1.
+step "0. Preflight"
+
+health=$(curl -sS "${HC}/r6/fhir/health" 2>/dev/null)
+[ -z "$health" ] && die "The guardrail proxy is not answering on ${HC}.
+Is it up?  docker compose ps
+On macOS, port 5000 belongs to AirPlay Receiver — set HEALTHCLAW_PORT=5099."
+
+python3 - "$health" <<'PY' || exit 2
+import json, sys
+h = json.loads(sys.argv[1])
+mode = h.get("mode")
+up = h.get("checks", {}).get("upstream")
+print(f"    proxy version {h.get('version')}, mode {mode}")
+
+if mode != "upstream":
+    print("""
+\033[31mThe proxy is running in LOCAL mode — it is not talking to Aidbox at all.\033[0m
+Everything below would pass against the proxy's own SQLite store and prove
+nothing about Aidbox. Check FHIR_UPSTREAM_URL reached the container:
+    docker compose exec healthclaw printenv FHIR_UPSTREAM_URL""")
+    sys.exit(1)
+
+status = up.get("status") if isinstance(up, dict) else up
+if status != "connected":
+    print(f"""
+\033[31mThe proxy cannot reach Aidbox (upstream status: {status}).\033[0m
+The two causes, in the order they actually happen:
+
+  1. Aidbox is not activated. It answers EVERY route with a 302 to
+     "Log in to activate Aidbox" — including /health, so this looks like a
+     network fault rather than a licence one. Open http://localhost:8080 and
+     click "Continue with Aidbox account", or set BOX_LICENSE in .env.
+
+  2. The proxy image predates upstream authentication. Images published
+     before v1.10.0 ignore FHIR_UPSTREAM_CLIENT_ID and
+     FHIR_UPSTREAM_CLIENT_SECRET entirely, so the proxy calls Aidbox
+     anonymously and the AccessPolicy refuses it. Pull again:
+       docker compose pull && docker compose up -d""")
+    sys.exit(1)
+print("  \033[32mPASS\033[0m proxy is in upstream mode and connected to Aidbox")
+PY
+
+# The example claims the proxy needs its own credential. That claim is only
+# worth anything if Aidbox refuses callers who lack one — and Aidbox runs here
+# with BOX_SECURITY_DEV_MODE on, which is exactly the setting that could make
+# the AccessPolicy vacuous. Assert it rather than assume it.
+anon=$(curl -sS -o /dev/null -w '%{http_code}' "${AIDBOX_URL}/fhir/Patient/pt-demo")
+if [ "$anon" = "200" ]; then
+  bad "Aidbox served Patient/pt-demo to an ANONYMOUS caller (HTTP 200).
+       The AccessPolicy is not constraining anything, so 'the proxy holds its
+       own credential' is not demonstrated here. Check BOX_SECURITY_DEV_MODE."
+else
+  ok "Aidbox refuses anonymous callers (HTTP ${anon}) — the credential matters"
+fi
+
+# ---------------------------------------------------------------------------
+# READS are authenticated too, because READ_AUTH_ENABLED is on. A tenant
+# header alone gets a 401, not a redacted record — the same token that
+# authorises a write is what proves the tenant claim on a read.
+#
+# This is minted here, before step 1, rather than in step 3 where it used to
+# live. Without it every read below returns an OperationOutcome, and an
+# OperationOutcome contains no PHI: the redaction assertions passed
+# VACUOUSLY, on a refusal rather than on a record. That is why step 1 now
+# checks it received a Patient before it checks what the Patient contains.
+token=$(curl -sS -X POST -H 'Content-Type: application/json' \
+  -H "X-Tenant-Id: ${TENANT}" -d "{\"tenant_id\":\"${TENANT}\"}" \
+  "${HC}/r6/fhir/internal/step-up-token" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))")
+[ -z "$token" ] && die "Could not mint a step-up token on ${HC}.
+Every read and write below needs one. Is STEP_UP_SECRET set in .env?"
+READ_AUTH=(-H "X-Tenant-Id: ${TENANT}" -H "X-Step-Up-Token: ${token}")
+
+# ---------------------------------------------------------------------------
+step "1. The same resource, both ways"
+
+direct=$(curl -sS -u "${AIDBOX_CLIENT}:${AIDBOX_SECRET}" \
+  "${AIDBOX_URL}/fhir/Patient/pt-demo")
+echo "  direct from Aidbox:"
+echo "$direct" | python3 -c "import json,sys; r=json.load(sys.stdin); print('   ', json.dumps({k:r.get(k) for k in ('name','identifier','birthDate','address')})[:300])"
+
+proxied=$(curl -sS "${READ_AUTH[@]}" "${HC}/r6/fhir/Patient/pt-demo")
+echo "  through the guardrail proxy:"
+echo "$proxied" | python3 -c "import json,sys; r=json.load(sys.stdin); print('   ', json.dumps({k:r.get(k) for k in ('resourceType','id','name','identifier','birthDate','address')})[:300])"
+
+# Three assertions, in this order. The first exists because the other two
+# are satisfied by ANY response that lacks the identifiers — including a
+# refusal, which is what this step was actually receiving.
+python3 - "$direct" "$proxied" <<'PY'
+import json, sys
+direct, proxied = json.loads(sys.argv[1]), json.loads(sys.argv[2])
+
+# 1. We are looking at the record, not at an error about the record.
+if proxied.get("resourceType") != "Patient" or proxied.get("id") != "pt-demo":
+    print("  \033[31mFAIL\033[0m the proxy did not return Patient/pt-demo. "
+          "Nothing below would be testing redaction:")
+    print("        " + json.dumps(proxied)[:300])
+    sys.exit(1)
+
+# 2. Aidbox really does hold the identified record, so the comparison means
+#    something.
+if "Alvarez" not in json.dumps(direct):
+    print("  \033[31mFAIL\033[0m Aidbox did not return the identified record; "
+          "is the seed loaded?")
+    sys.exit(1)
+
+# 3. The distinctive values are gone. Asserted on the values themselves, not
+#    on the shape of the mask: checking for '***masked***' would pass if
+#    redaction were replaced by a function returning that string and nothing
+#    else.
+raw = json.dumps(proxied)
+leaked = [tok for tok in ("Alvarez", "Maria", "MRN-88214", "221 Baker St",
+                          "555-867-5309", "1974-03-11") if tok in raw]
+if leaked:
+    print(f"  \033[31mFAIL\033[0m identifiers survived redaction: {leaked}")
+    sys.exit(1)
+print("  \033[32mPASS\033[0m Aidbox holds the full record; the agent's path does not")
+PY
+[ $? -ne 0 ] && fail=1
+
+# ---------------------------------------------------------------------------
+step "2. The read left a record"
+
+audit=$(curl -sS "${READ_AUTH[@]}" "${HC}/r6/fhir/AuditEvent?_count=5")
+echo "$audit" | python3 -c "
+import json,sys
+b=json.load(sys.stdin)
+# Same trap as step 1: a refusal is a JSON object with no entries, and 'no
+# PHI in it' is trivially true of a refusal. Check the shape first.
+if b.get('resourceType') != 'Bundle':
+    print('  \033[31mFAIL\033[0m expected a Bundle of AuditEvents, got:')
+    print('        ' + json.dumps(b)[:300]); sys.exit(1)
+n=b.get('total', len(b.get('entry',[])))
+print(f'    AuditEvent entries: {n}')
+if not b.get('entry'):
+    print('  \033[31mFAIL\033[0m the read emitted no AuditEvent'); sys.exit(1)
+raw=json.dumps(b)
+for tok in ('Alvarez','MRN-88214','221 Baker St','555-867-5309'):
+    if tok in raw:
+        print(f'  \033[31mFAIL\033[0m PHI in the audit trail: {tok}'); sys.exit(1)
+print('  \033[32mPASS\033[0m audit written, and PHI-free')
+"
+[ $? -ne 0 ] && fail=1
+
+# ---------------------------------------------------------------------------
+step "3. A write, and two gates that do not substitute for each other"
+
+# Four requests, not two. A sequence of two refusals only shows that SOME
+# refusal happened; it cannot tell you whether the second gate would have
+# accepted the first gate's credential. The matrix can: each gate is
+# presented on its own, and each one refuses on its own.
+#
+#   neither          -> 428   human confirmation is missing
+#   confirmed only   -> 401   a confirmation is not a credential
+#   token only       -> 428   a credential is not a confirmation
+#   both             -> 201   and only then
+#
+# The bare request reports 428 rather than 401 because the human-in-the-loop
+# check runs in a before_request hook, ahead of every handler's auth gate.
+# That ordering is deliberate — it is what stops an unauthenticated caller
+# reaching the handler — so a bare write reports the human gate, not the
+# credential one. An earlier version of this script asserted the reverse.
+#
+# tests/test_aidbox_example_tells_the_truth.py replays this exact matrix
+# against the app in CI, so these four numbers cannot drift from the server.
+body='{"resourceType":"Observation","status":"final",
+       "subject":{"reference":"Patient/pt-demo"},
+       "effectiveDateTime":"2026-08-11",
+       "code":{"coding":[{"system":"http://loinc.org","code":"85354-9"}]},
+       "valueQuantity":{"value":128,"unit":"mmHg"}}'
+
+write() {  # write <expected> <label> [extra curl args...]
+  local expected="$1" label="$2"; shift 2
+  local code
+  code=$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+    -H "X-Tenant-Id: ${TENANT}" -H 'Content-Type: application/fhir+json' \
+    "$@" -d "$body" "${HC}/r6/fhir/Observation")
+  printf '    %-26s -> HTTP %s\n' "$label" "$code"
+  [ "$code" = "$expected" ] && ok "$label" \
+                            || bad "$label: expected ${expected}, got ${code}"
+}
+
+# $token was minted before step 1 — reads need it too.
+write 428 "neither gate"
+write 401 "confirmed, no credential" -H 'X-Human-Confirmed: true'
+write 428 "credential, no human" -H "X-Step-Up-Token: ${token}"
+write 201 "both gates satisfied" -H "X-Step-Up-Token: ${token}" \
+                                 -H 'X-Human-Confirmed: true'
+
+# The write is only real if Aidbox holds it. Ask Aidbox, going around the
+# proxy — the proxy reporting its own 201 says nothing about storage.
+landed=$(curl -sS -u "${AIDBOX_CLIENT}:${AIDBOX_SECRET}" \
+  "${AIDBOX_URL}/fhir/Observation?subject=Patient/pt-demo&code=85354-9" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin).get('total',0))" 2>/dev/null)
+[ "${landed:-0}" -ge 1 ] && ok "the Observation reached Aidbox (${landed} found)" \
+                         || bad "the write returned 201 but Aidbox has no such Observation"
+
+# ---------------------------------------------------------------------------
+step "4. Grade the deployment"
+
+curl -sS "${HC}/r6/fhir/\$conformance?format=text" | sed -n '1,2p' | sed 's/^/    /'
+
+# NOT an assertion that the grade is A. In upstream mode it is B, and the one
+# property that fails — error fidelity — fails for a reason worth stating
+# rather than hiding behind a softer threshold: a search carrying an unknown
+# parameter is forwarded to Aidbox, which answers 404/502, instead of being
+# refused by the guardrail with an OperationOutcome naming the parameter.
+# That is a real gap in proxy mode, tracked as HealthClawGuardrails#498.
+#
+# So the assertion is: every OTHER property holds, and error fidelity is the
+# only failure. Anything else regressing goes red, and the day the gap is
+# closed this still passes at 7/7 without an edit.
+curl -sS "${HC}/r6/fhir/\$conformance" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+score = d['score']
+failed = [p['key'] for p in d.get('properties', []) if not p.get('passed')]
+print(f\"    grade {d.get('grade')} ({score['passed']}/{score['total']})\")
+KNOWN = {'error_fidelity'}
+unexpected = set(failed) - KNOWN
+if unexpected:
+    print('  \033[31mFAIL\033[0m properties that should hold did not: '
+          + ', '.join(sorted(unexpected)))
+    sys.exit(1)
+if failed:
+    print('  \033[32mPASS\033[0m ' + str(score['passed']) + '/'
+          + str(score['total']) + ' — the only failure is error fidelity,')
+    print('       which in upstream mode measures how Aidbox answers an '
+          'unknown search')
+    print('       parameter, not how the guardrail does. Known, and stated '
+          'rather than')
+    print('       graded away.')
+else:
+    print('  \033[32mPASS\033[0m Grade A, 7/7')
+"
+[ $? -ne 0 ] && fail=1
+
+# ---------------------------------------------------------------------------
+step "5. What the agent actually connects to"
+
+# The diagram at the top of the README opens with the MCP server, and for a
+# long time this example never started it: the proxy's health check called
+# curl, which is not in that image, so it reported unhealthy forever and the
+# mcp service — depends_on: service_healthy — never came up. Nothing noticed,
+# because nothing asked. This step asks.
+MCP="http://localhost:${MCP_PORT:-3001}"
+mcp_code=$(curl -sS -o /dev/null -w '%{http_code}' -X POST "${MCP}/mcp/rpc" \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}')
+echo "    tools/list, no token      -> HTTP ${mcp_code}"
+[ "$mcp_code" = "401" ] && ok "the MCP server refuses unauthenticated callers" \
+                        || bad "expected 401 from an unauthenticated tools/list, got ${mcp_code}"
+
+tools=$(curl -sS -X POST "${MCP}/mcp/rpc" -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer ${MCP_AUTH_TOKEN}" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('result',{}).get('tools',[])))" 2>/dev/null)
+echo "    tools/list, with token    -> ${tools:-0} tools"
+[ "${tools:-0}" -gt 0 ] && ok "the agent's tool surface is served, and gated" \
+                        || bad "authenticated tools/list returned no tools"
+
+# ---------------------------------------------------------------------------
+if [ "$fail" -ne 0 ]; then
+  printf '\n\033[31mWalkthrough FAILED.\033[0m A guardrail this example claims did not hold.\n'
+  exit 1
+fi
+printf '\n\033[32mWalkthrough passed.\033[0m The agent did useful work and could not finish alone.\n'


### PR DESCRIPTION
Adds `aidbox-integrations/healthclaw-guardrails/` — Aidbox as the system of record, with a guardrail proxy in front of it enforcing four things the FHIR authorization model does not express: **redact on read, audit every access, step up on writes, and hold anything irreversible for a human.**

```
AI agent ──▶ MCP server ──▶ Guardrail proxy ──▶ Aidbox
  :3001                        :5000              :8080
```

Nothing about the Aidbox side is unusual, and that is the point. The layer is additive; Aidbox keeps behaving like a FHIR server and still holds the complete, fully-identified record. Companion to an article written with Health Samurai.

## What it demonstrates

`scripts/walkthrough.sh` runs six steps and **fails loudly** when a property does not hold, rather than printing OK whatever happens:

| | |
|---|---|
| **0** | the proxy is in upstream mode, and Aidbox refuses anonymous callers |
| **1** | the same Patient — identified from Aidbox, redacted through the proxy |
| **2** | the read left an AuditEvent, and the AuditEvent carries no PHI |
| **3** | a write, and two gates that do not substitute for each other |
| **4** | the guardrail conformance grade for this deployment |
| **5** | the MCP tool surface: 401 unauthenticated, 27 tools authenticated |

Step 1, live:

```
direct from Aidbox:  "name": [{"given": ["Maria"], "family": "Alvarez"}],
                     "identifier": [{"value": "MRN-88214"}],
                     "birthDate": "1974-03-11",
                     "address": [{"line": ["221 Baker St"], "city": "Pittsburgh"}]

through the proxy:   "name": [{"family": "A.", "given": ["M."]}],
                     "identifier": [{"value": "***8214"}],
                     "birthDate": "1974",
                     "address": [{"state": "PA"}]
```

Step 3 is a four-row matrix rather than two refusals in sequence, because a sequence only shows that *some* refusal happened:

| `X-Human-Confirmed` | `X-Step-Up-Token` | |
|---|---|---|
| — | — | **428** confirmation missing |
| `true` | — | **401** a confirmation is not a credential |
| — | valid | **428** a credential is not a confirmation |
| `true` | valid | **201** |

The write is then confirmed by querying Aidbox directly — the proxy reporting its own 201 says nothing about storage.

## Two things stated rather than smoothed over

**The grade is B (6/7), not A.** In upstream mode the error-fidelity property measures how *Aidbox* answers an unknown search parameter (404/502) rather than how the guardrail does. Step 4 asserts that every *other* property holds, so the assertion stays correct on the day that gap closes. Tracked as [HealthClawGuardrails#498](https://github.com/aks129/HealthClawGuardrails/issues/498).

**The human-confirmation header is set by the caller**, so it evidences a human the way a checkbox does. It is documented as a compensating control, not proof. The README's *What this example does not show* section covers this and two others.

## Notes for reviewers

- **Aidbox activation.** `BOX_LICENSE` is passed through as a bare env key, deliberately: an *empty* licence is worse than a missing one — Aidbox refuses to boot with "License is invalid ... not in correct format" — so absent from `.env` means absent from the container. With it unset, `docker compose up -d` waits on Aidbox's health check while you click *Continue with Aidbox account*, then starts the proxy on its own.
- **The health check requires a literal 200**, not `curl -f`. An unactivated Aidbox answers `/health` with a 302 to its activation page, and `curl -f` only fails on 4xx/5xx — so the obvious check reports an unactivated Aidbox as healthy.
- **The MCP server requires `MCP_AUTH_TOKEN`** and refuses to start without one. `MCP_PUBLIC_DEMO=true` is the documented alternative and is deliberately not used here.
- `qa/` holds a Playwright harness that asserts the same properties from a browser and records the run, so the recording and the assertions come from the same requests.

## Verification

Run end to end against `healthsamurai/aidboxone:edge` on the published `ghcr.io` images — all six steps green, including a fresh `docker compose pull` to confirm the pinned tags resolve.

Guardrail proxy is MIT: <https://github.com/aks129/HealthClawGuardrails>